### PR TITLE
fix: remove not using permissions

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,6 +1,6 @@
 # Privacy Policy for COSE - 多平台文章同步
 
-**Last Updated: December 5, 2025**
+**Last Updated: December 13, 2025**
 
 ## Overview
 
@@ -24,20 +24,19 @@ All data processed by COSE remains on your local device:
 
 - **Article Content**: Your article title, body, and formatting are only read from md.doocs.org and transferred directly to the target publishing platforms within your browser.
 - **Login Status**: The extension checks login cookies on target platforms (CSDN, Juejin, WeChat, etc.) solely to verify if you are logged in. This information is not stored or transmitted.
-- **User Preferences**: Any settings are stored locally using Chrome's storage API and never leave your device.
+- **User Preferences**: COSE does not persist user preferences or settings.
 
 ## Permissions Explained
 
 | Permission | Purpose |
 |------------|---------|
-| `storage` | Save user preferences locally |
-| `tabs` | Open new tabs for target platforms |
 | `tabGroups` | Organize sync tabs into groups |
-| `activeTab` | Read article content from the editor |
+| `activeTab` | Temporarily access the current tab when you initiate a sync |
 | `scripting` | Fill article content into platform editors |
 | `cookies` | Check platform login status |
 | `debugger` | Simulate paste events for WeChat editor |
-| `clipboardRead/Write` | Handle formatted content for syncing |
+| `clipboardRead` | Read formatted content (HTML) from the clipboard for syncing |
+| `clipboardWrite` | Write content to the clipboard when needed for syncing |
 
 ## Third-Party Services
 

--- a/manifest.json
+++ b/manifest.json
@@ -4,8 +4,6 @@
   "version": "1.0.2",
   "description": "Create Once, Sync Everywhere. 一键将文章同步到多个平台",
   "permissions": [
-    "storage",
-    "tabs",
     "tabGroups",
     "activeTab",
     "scripting",


### PR DESCRIPTION
## PR Description

fix #3 

### Background
Chrome Web Store review rejected version `1.0.2` due to overbroad / unused permissions:
- `storage` was requested but not used by the extension code.
- `tabs` was flagged as unnecessary for the APIs currently used.

### What changed
- Removed `storage` and `tabs` from the extension `permissions` list to comply with the “least privilege” policy.
- Updated PRIVACY.md to reflect the current permission set and remove outdated explanations.

### Files changed
- cose/manifest.json
- cose/PRIVACY.md

### Notes
The extension still uses `chrome.tabs.*` APIs (e.g. creating/updating tabs), but those calls work without requesting the `tabs` permission. No `chrome.storage` / `browser.storage` usage exists in the codebase, so `storage` was removed.

### Checklist
- [x] Requested permissions are actively used and necessary
- [x] Privacy policy matches the manifest permissions