### PR TITLE
feat: add zhihu support

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Create Once Sync Everywhere
 | CSDN | 自动填充 Markdown 内容 |
 | 掘金 | 自动填充 Markdown 内容 |
 | 微信公众号 | 保留完整样式，自动保存草稿 |
+| 知乎 | 自动填充 Markdown 内容 |
 
 更多想要添加的平台欢迎提 [issue](https://github.com/doocs/cose/issues) 。
 

--- a/inject.js
+++ b/inject.js
@@ -66,6 +66,7 @@
     { id: 'csdn', name: 'CSDN', icon: 'https://g.csdnimg.cn/static/logo/favicon32.ico', title: 'CSDN', type: 'csdn' },
     { id: 'juejin', name: 'Juejin', icon: 'https://lf-web-assets.juejin.cn/obj/juejin-web/xitu_juejin_web/static/favicons/favicon-32x32.png', title: '掘金', type: 'juejin' },
     { id: 'wechat', name: 'WeChat', icon: 'https://res.wx.qq.com/a/wx_fed/assets/res/NTI4MWU5.ico', title: '微信公众号', type: 'wechat' },
+    { id: 'zhihu', name: 'Zhihu', icon: 'https://static.zhihu.com/heifetz/favicon.ico', title: '知乎', type: 'zhihu' },
   ]
 
   // 暴露 $cose 全局对象

--- a/manifest.json
+++ b/manifest.json
@@ -23,6 +23,7 @@
     "https://*.51cto.com/*",
     "https://*.weibo.com/*",
     "https://mp.weixin.qq.com/*",
+    "https://*.zhihu.com/*",
     "https://*.sspai.com/*",
     "https://*.xueqiu.com/*",
     "https://*.eastmoney.com/*",

--- a/platforms.js
+++ b/platforms.js
@@ -22,6 +22,13 @@ const PLATFORMS = [
     // 先打开草稿箱，再自动点击新建
     publishUrl: 'https://mp.weixin.qq.com/cgi-bin/appmsg?t=media/appmsg_edit_v2&action=edit&isNew=1&type=10',
   },
+  {
+    id: 'zhihu',
+    name: 'Zhihu',
+    icon: 'https://static.zhihu.com/heifetz/favicon.ico',
+    url: 'https://www.zhihu.com',
+    publishUrl: 'https://zhuanlan.zhihu.com/write',
+  },
 ]
 
 // 导出供其他脚本使用


### PR DESCRIPTION
## Summary

Add Zhihu (知乎) platform support for article synchronization.

## Changes

### Browser Extension
- Implemented Zhihu-specific sync logic in syncToPlatform() using the "Import Document" feature
- The extension navigates to `https://zhuanlan.zhihu.com/write`, fills the title, and uploads the markdown content as a `.md` file

## Implementation Details

Instead of direct content pasting (which fails on Zhihu), this PR uses Zhihu's native "Import Document" feature:

1. Open Zhihu writing page
2. Fill article title
3. Click "导入" (Import) button → Click "导入文档" (Import Document) submenu
4. Programmatically create and upload a `.md` file using the File API

### Technical Notes
- Button selectors use `innerText.includes()` to handle zero-width characters in Zhihu's UI
- File is created in memory using `new File()` API with `text/plain` MIME type
- Both `change` event and drag-drop fallback are triggered for compatibility

## Testing

1. Install the browser extension from cose/ directory
2. Open the editor and select Zhihu for sync
3. Verify the article title and content are imported correctly