### PR TITLE
feat: add toutiao support #10

### DIFF
--- a/src/inject.js
+++ b/src/inject.js
@@ -67,6 +67,7 @@
     { id: 'juejin', name: 'Juejin', icon: 'https://lf-web-assets.juejin.cn/obj/juejin-web/xitu_juejin_web/static/favicons/favicon-32x32.png', title: '掘金', type: 'juejin' },
     { id: 'wechat', name: 'WeChat', icon: 'https://res.wx.qq.com/a/wx_fed/assets/res/NTI4MWU5.ico', title: '微信公众号', type: 'wechat' },
     { id: 'zhihu', name: 'Zhihu', icon: 'https://static.zhihu.com/heifetz/favicon.ico', title: '知乎', type: 'zhihu' },
+    { id: 'toutiao', name: 'Toutiao', icon: 'https://sf3-cdn-tos.toutiaostatic.com/obj/eden-cn/uhbfnupkbps/toutiao_favicon.ico', title: '今日头条', type: 'toutiao' },
   ]
 
   // 暴露 $cose 全局对象

--- a/src/platforms/index.js
+++ b/src/platforms/index.js
@@ -38,6 +38,15 @@ const PLATFORMS = [
     title: '知乎',
     type: 'zhihu',
   },
+  {
+    id: 'toutiao',
+    name: 'Toutiao',
+    icon: 'https://sf3-cdn-tos.toutiaostatic.com/obj/eden-cn/uhbfnupkbps/toutiao_favicon.ico',
+    url: 'https://mp.toutiao.com',
+    publishUrl: 'https://mp.toutiao.com/profile_v4/graphic/publish',
+    title: '今日头条',
+    type: 'toutiao',
+  },
 ]
 
 // 登录检测配置
@@ -76,6 +85,15 @@ const LOGIN_CHECK_CONFIG = {
       avatar: response?.avatar_url,
     }),
   },
+  toutiao: {
+    api: 'https://mp.toutiao.com/mp/agw/media/get_media_info',
+    method: 'GET',
+    checkLogin: (response) => response?.err_no === 0 && response?.data?.media?.display_name,
+    getUserInfo: (response) => ({
+      username: response?.data?.media?.display_name,
+      avatar: response?.data?.media?.https_avatar_url,
+    }),
+  },
 }
 
 // 根据 hostname 获取平台填充函数
@@ -84,6 +102,7 @@ function getPlatformFiller(hostname) {
   if (hostname.includes('juejin.cn')) return 'juejin'
   if (hostname.includes('mp.weixin.qq.com')) return 'wechat'
   if (hostname.includes('zhihu.com')) return 'zhihu'
+  if (hostname.includes('toutiao.com')) return 'toutiao'
   return 'generic'
 }
 

--- a/src/platforms/toutiao.js
+++ b/src/platforms/toutiao.js
@@ -1,0 +1,65 @@
+// 今日头条平台配置
+const ToutiaoPlatform = {
+  id: 'toutiao',
+  name: 'Toutiao',
+  icon: 'https://sf3-cdn-tos.toutiaostatic.com/obj/eden-cn/uhbfnupkbps/toutiao_favicon.ico',
+  url: 'https://mp.toutiao.com',
+  publishUrl: 'https://mp.toutiao.com/profile_v4/graphic/publish',
+  title: '今日头条',
+  type: 'toutiao',
+}
+
+// 今日头条登录检测配置
+const ToutiaoLoginConfig = {
+  api: 'https://mp.toutiao.com/mp/agw/media/get_media_info',
+  method: 'GET',
+  checkLogin: (response) => response?.err_no === 0 && response?.data?.media?.display_name,
+  getUserInfo: (response) => ({
+    username: response?.data?.media?.display_name,
+    avatar: response?.data?.media?.https_avatar_url,
+  }),
+}
+
+// 今日头条内容填充函数
+async function fillToutiaoContent(content, waitFor, setInputValue) {
+  const { title, body, markdown } = content
+  const contentToFill = body || markdown || ''
+
+  // 填充标题 - 头条使用 textarea 作为标题输入
+  const titleInput = await waitFor('textarea[placeholder*="标题"], input[placeholder*="标题"], .editor-title textarea, .title-input textarea')
+  if (titleInput) {
+    titleInput.focus()
+    // 使用 nativeInputValueSetter 触发 React 状态更新
+    const nativeInputValueSetter = Object.getOwnPropertyDescriptor(window.HTMLTextAreaElement.prototype, 'value')?.set 
+      || Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value')?.set
+    if (nativeInputValueSetter) {
+      nativeInputValueSetter.call(titleInput, title)
+    } else {
+      titleInput.value = title
+    }
+    titleInput.dispatchEvent(new Event('input', { bubbles: true }))
+    titleInput.dispatchEvent(new Event('change', { bubbles: true }))
+    console.log('[COSE] 头条标题填充成功')
+  } else {
+    console.log('[COSE] 头条未找到标题输入框')
+  }
+
+  // 等待编辑器加载
+  await new Promise(resolve => setTimeout(resolve, 1000))
+
+  // 头条使用富文本编辑器
+  const editor = document.querySelector('.ProseMirror, [contenteditable="true"], .editor-content')
+  if (editor) {
+    editor.focus()
+    editor.innerHTML = contentToFill.replace(/\n/g, '<br>')
+    editor.dispatchEvent(new Event('input', { bubbles: true }))
+    console.log('[COSE] 头条内容填充成功')
+  } else {
+    console.log('[COSE] 头条未找到编辑器')
+  }
+}
+
+// 导出
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = { ToutiaoPlatform, ToutiaoLoginConfig, fillToutiaoContent }
+}


### PR DESCRIPTION
## Summary
Add Toutiao/Jinritoutiao (今日头条) platform support for article synchronization.

## Changes

- Added Toutiao platform configuration in `PLATFORMS` array
- Implemented login detection using Toutiao's media info API
- Added content filling logic for Toutiao's rich text editor

## Implementation Details

**Login Detection:**
- Uses `https://mp.toutiao.com/mp/agw/media/get_media_info` API endpoint
- Parses `response.data.media.display_name` for username
- Parses `response.data.media.https_avatar_url` for avatar
- Handles `text/plain` content-type response (Toutiao returns JSON with text/plain header)

**Content Filling:**
- Title: Uses `textarea[placeholder*="标题"]` selector with React-compatible value setter (`nativeInputValueSetter`)
- Content: Fills into ProseMirror/contenteditable editor with HTML content

## Technical Notes
- Toutiao API returns JSON data but with `content-type: text/plain`, so the extension parses both `application/json` and `text/plain` responses
- React state updates require using `Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, 'value').set` to properly trigger re-renders
- Both `input` and `change` events are dispatched for compatibility

## Testing
1. Install the browser extension from [cose/](cci:7://file:///Users/jh/Repo/md/cose:0:0-0:0) directory
2. Log in to Toutiao at `https://mp.toutiao.com`
3. Open the editor and verify Toutiao shows your account name
4. Select Toutiao for sync and verify title/content are filled correctly