### PR TITLE
fix: toutiao title empty

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -720,34 +720,30 @@ function fillContentOnPage(content, platformId) {
     }
     // 今日头条
     else if (host.includes('toutiao.com')) {
-      // 填充标题 - 头条使用 textarea 作为标题输入
-      const titleInput = await waitFor('textarea[placeholder*="标题"], input[placeholder*="标题"], .editor-title textarea, .title-input textarea')
+      // 填充标题 - 头条使用 textarea
+      const titleInput = await waitFor('textarea[placeholder*="标题"]')
       if (titleInput) {
         titleInput.focus()
-        // 使用 nativeInputValueSetter 触发 React 状态更新
-        const nativeInputValueSetter = Object.getOwnPropertyDescriptor(window.HTMLTextAreaElement.prototype, 'value')?.set 
-          || Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value')?.set
-        if (nativeInputValueSetter) {
-          nativeInputValueSetter.call(titleInput, title)
-        } else {
-          titleInput.value = title
-        }
-        titleInput.dispatchEvent(new Event('input', { bubbles: true }))
+        // 模拟用户输入
+        const nativeSetter = Object.getOwnPropertyDescriptor(window.HTMLTextAreaElement.prototype, 'value').set
+        nativeSetter.call(titleInput, title)
+        titleInput.dispatchEvent(new InputEvent('input', { bubbles: true, data: title, inputType: 'insertText' }))
         titleInput.dispatchEvent(new Event('change', { bubbles: true }))
-        console.log('[COSE] 头条标题填充成功')
+        titleInput.dispatchEvent(new Event('blur', { bubbles: true }))
+        console.log('[COSE] 头条标题填充成功:', title)
       } else {
         console.log('[COSE] 头条未找到标题输入框')
       }
       
       // 等待编辑器加载
-      await new Promise(resolve => setTimeout(resolve, 1000))
+      await new Promise(resolve => setTimeout(resolve, 500))
       
-      // 头条使用富文本编辑器
-      const editor = document.querySelector('.ProseMirror, [contenteditable="true"], .editor-content')
+      // 头条使用 ProseMirror 富文本编辑器
+      const editor = document.querySelector('.ProseMirror')
       if (editor) {
         editor.focus()
         editor.innerHTML = body || contentToFill.replace(/\n/g, '<br>')
-        editor.dispatchEvent(new Event('input', { bubbles: true }))
+        editor.dispatchEvent(new InputEvent('input', { bubbles: true }))
         console.log('[COSE] 头条内容填充成功')
       } else {
         console.log('[COSE] 头条未找到编辑器')

--- a/src/platforms/toutiao.js
+++ b/src/platforms/toutiao.js
@@ -25,34 +25,30 @@ async function fillToutiaoContent(content, waitFor, setInputValue) {
   const { title, body, markdown } = content
   const contentToFill = body || markdown || ''
 
-  // 填充标题 - 头条使用 textarea 作为标题输入
-  const titleInput = await waitFor('textarea[placeholder*="标题"], input[placeholder*="标题"], .editor-title textarea, .title-input textarea')
+  // 填充标题 - 头条使用 textarea
+  const titleInput = await waitFor('textarea[placeholder*="标题"]')
   if (titleInput) {
     titleInput.focus()
-    // 使用 nativeInputValueSetter 触发 React 状态更新
-    const nativeInputValueSetter = Object.getOwnPropertyDescriptor(window.HTMLTextAreaElement.prototype, 'value')?.set 
-      || Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value')?.set
-    if (nativeInputValueSetter) {
-      nativeInputValueSetter.call(titleInput, title)
-    } else {
-      titleInput.value = title
-    }
-    titleInput.dispatchEvent(new Event('input', { bubbles: true }))
+    // 模拟用户输入
+    const nativeSetter = Object.getOwnPropertyDescriptor(window.HTMLTextAreaElement.prototype, 'value').set
+    nativeSetter.call(titleInput, title)
+    titleInput.dispatchEvent(new InputEvent('input', { bubbles: true, data: title, inputType: 'insertText' }))
     titleInput.dispatchEvent(new Event('change', { bubbles: true }))
-    console.log('[COSE] 头条标题填充成功')
+    titleInput.dispatchEvent(new Event('blur', { bubbles: true }))
+    console.log('[COSE] 头条标题填充成功:', title)
   } else {
     console.log('[COSE] 头条未找到标题输入框')
   }
 
   // 等待编辑器加载
-  await new Promise(resolve => setTimeout(resolve, 1000))
+  await new Promise(resolve => setTimeout(resolve, 500))
 
-  // 头条使用富文本编辑器
-  const editor = document.querySelector('.ProseMirror, [contenteditable="true"], .editor-content')
+  // 头条使用 ProseMirror 富文本编辑器
+  const editor = document.querySelector('.ProseMirror')
   if (editor) {
     editor.focus()
     editor.innerHTML = contentToFill.replace(/\n/g, '<br>')
-    editor.dispatchEvent(new Event('input', { bubbles: true }))
+    editor.dispatchEvent(new InputEvent('input', { bubbles: true }))
     console.log('[COSE] 头条内容填充成功')
   } else {
     console.log('[COSE] 头条未找到编辑器')


### PR DESCRIPTION
## Summary
Fix Toutiao title not being filled when syncing articles.

fix #13 

## Changes
- Change title selector to prioritize `textarea[placeholder*="标题"]` (Toutiao uses textarea, not input)
- Use `Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, 'value').set` to properly set value for React-controlled textarea
- Dispatch `InputEvent` with `inputType: 'insertText'` instead of plain `Event` to simulate real user input
- Add `blur` event to trigger React state persistence
- Also parse `text/plain` content-type responses as JSON (Toutiao API returns JSON with `text/plain` header)

## Testing
1. Login to https://mp.toutiao.com
2. Open md editor, write an article
3. Click "发布" → select Toutiao
4. Verify both title and content are filled correctly

## Related
Fixes title autofill issue for Toutiao platform.