### PR TITLE
feat: cnblogs platform sync

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "COSE - 多平台文章同步",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Create Once, Sync Everywhere. 一键将文章同步到多个平台",
   "permissions": [
     "tabGroups",
@@ -28,7 +28,8 @@
     "https://*.eastmoney.com/*",
     "https://*.wordpress.com/*",
     "https://*.wordpress.org/*",
-    "https://md.doocs.org/*"
+    "https://md.doocs.org/*",
+    "https://*.cnblogs.com/*"
   ],
   "action": {
     "default_icon": {

--- a/src/background.js
+++ b/src/background.js
@@ -6,6 +6,7 @@ const PLATFORMS = [
   { id: 'zhihu', name: 'Zhihu', icon: 'https://static.zhihu.com/heifetz/favicon.ico', url: 'https://www.zhihu.com', publishUrl: 'https://zhuanlan.zhihu.com/write' },
   { id: 'toutiao', name: 'Toutiao', icon: 'https://sf3-cdn-tos.toutiaostatic.com/obj/eden-cn/uhbfnupkbps/toutiao_favicon.ico', url: 'https://mp.toutiao.com', publishUrl: 'https://mp.toutiao.com/profile_v4/graphic/publish' },
   { id: 'segmentfault', name: 'SegmentFault', icon: 'https://static.segmentfault.com/main_site_next/prod/favicon.ico', url: 'https://segmentfault.com', publishUrl: 'https://segmentfault.com/write' },
+  { id: 'cnblogs', name: 'Cnblogs', icon: 'https://www.cnblogs.com/favicon.ico', url: 'https://www.cnblogs.com', publishUrl: 'https://i.cnblogs.com/posts/edit' },
 ]
 
 // 当前同步任务的 Tab Group ID
@@ -107,6 +108,15 @@ const LOGIN_CHECK_CONFIG = {
     cookieNames: ['PHPSESSID'],
     fetchUserInfoFromPage: true,
     userInfoUrl: 'https://segmentfault.com/write',
+  },
+  cnblogs: {
+    api: 'https://i.cnblogs.com/api/user',
+    method: 'GET',
+    checkLogin: (response) => response?.loginName,
+    getUserInfo: (response) => ({
+      username: response?.displayName || response?.loginName,
+      avatar: response?.avatarName ? `https:${response.avatarName}` : '',
+    }),
   },
 }
 
@@ -814,6 +824,38 @@ function fillContentOnPage(content, platformId) {
         } else {
           console.log('[COSE] 思否 未找到编辑器')
         }
+      }
+    }
+    // 博客园
+    else if (host.includes('cnblogs.com')) {
+      // 等待页面加载
+      await new Promise(resolve => setTimeout(resolve, 1000))
+      
+      // 填充标题 - 博客园标题输入框
+      const titleInput = await waitFor('input[placeholder="标题"]') || document.querySelector('input')
+      if (titleInput) {
+        titleInput.focus()
+        titleInput.value = title
+        titleInput.dispatchEvent(new Event('input', { bubbles: true }))
+        titleInput.dispatchEvent(new Event('change', { bubbles: true }))
+        console.log('[COSE] 博客园标题填充成功')
+      } else {
+        console.log('[COSE] 博客园未找到标题输入框')
+      }
+      
+      // 等待编辑器加载
+      await new Promise(resolve => setTimeout(resolve, 500))
+      
+      // 博客园使用 id="md-editor" 的 textarea 作为 Markdown 编辑器
+      const editor = document.querySelector('#md-editor') || document.querySelector('textarea.not-resizable')
+      if (editor) {
+        editor.focus()
+        editor.value = contentToFill
+        editor.dispatchEvent(new Event('input', { bubbles: true }))
+        editor.dispatchEvent(new Event('change', { bubbles: true }))
+        console.log('[COSE] 博客园内容填充成功')
+      } else {
+        console.log('[COSE] 博客园未找到编辑器')
       }
     }
     // 通用处理

--- a/src/inject.js
+++ b/src/inject.js
@@ -69,6 +69,7 @@
     { id: 'zhihu', name: 'Zhihu', icon: 'https://static.zhihu.com/heifetz/favicon.ico', title: '知乎', type: 'zhihu' },
     { id: 'toutiao', name: 'Toutiao', icon: 'https://sf3-cdn-tos.toutiaostatic.com/obj/eden-cn/uhbfnupkbps/toutiao_favicon.ico', title: '今日头条', type: 'toutiao' },
     { id: 'segmentfault', name: 'SegmentFault', icon: 'https://youke2.picui.cn/s1/2025/12/21/6947b2935a41e.ico', title: '思否', type: 'segmentfault' },
+    { id: 'cnblogs', name: 'Cnblogs', icon: 'https://www.cnblogs.com/favicon.ico', title: '博客园', type: 'cnblogs' },
   ]
 
   // 暴露 $cose 全局对象

--- a/src/platforms/index.js
+++ b/src/platforms/index.js
@@ -56,6 +56,15 @@ const PLATFORMS = [
     title: '思否',
     type: 'segmentfault',
   },
+  {
+    id: 'cnblogs',
+    name: 'Cnblogs',
+    icon: 'https://www.cnblogs.com/favicon.ico',
+    url: 'https://www.cnblogs.com',
+    publishUrl: 'https://i.cnblogs.com/posts/edit',
+    title: '博客园',
+    type: 'cnblogs',
+  },
 ]
 
 // 登录检测配置
@@ -110,6 +119,15 @@ const LOGIN_CHECK_CONFIG = {
     fetchUserInfoFromPage: true,
     userInfoUrl: 'https://segmentfault.com/write',
   },
+  cnblogs: {
+    api: 'https://i.cnblogs.com/api/user',
+    method: 'GET',
+    checkLogin: (response) => response?.loginName,
+    getUserInfo: (response) => ({
+      username: response?.displayName || response?.loginName,
+      avatar: response?.avatarName ? `https:${response.avatarName}` : '',
+    }),
+  },
 }
 
 // 根据 hostname 获取平台填充函数
@@ -120,6 +138,7 @@ function getPlatformFiller(hostname) {
   if (hostname.includes('zhihu.com')) return 'zhihu'
   if (hostname.includes('toutiao.com')) return 'toutiao'
   if (hostname.includes('segmentfault.com')) return 'segmentfault'
+  if (hostname.includes('cnblogs.com')) return 'cnblogs'
   return 'generic'
 }
 


### PR DESCRIPTION
## Summary / 概述
为 COSE 添加了博客园平台支持，实现 Markdown 内容的自动同步功能。

## Related Issue / 关联 Issue
<!-- Link to the related issue(s) -->
<!-- 链接到相关的 issue -->
Closes #26 

## Type of Change / 更改类型
- [x] New feature / 新功能 (non-breaking change that adds functionality / 添加功能的非破坏性更改)

## Changes Made / 更改内容
- 添加了博客园平台配置
- 实现了博客园编辑器的内容自动填充
- 优化了文本区域选择逻辑，支持更多编辑器变体

## Implementation Details / 实现细节
**Key Changes / 主要更改:**
- 在 platforms/index.js 中添加了博客园平台配置
- 更新了 background.js 中的编辑器检测逻辑
- 移除了不必要的注释

**Technical Notes / 技术说明:**
- 使用 `#md-editor` 或 `textarea.not-resizable` 选择器定位博客园编辑器
- 添加了 500ms 延迟以确保页面完全加载

## Testing / 测试
### Testing Checklist / 测试清单
- [x] I have tested this code locally / 我已在本地测试此代码
- [x] I have tested on the affected platform(s) / 我已在受影响的平台上测试

### Manual Testing Steps / 手动测试步骤
1. 安装扩展并登录博客园
2. 在 COSE 中选择一篇文章
3. 点击同步到博客园
4. 确认内容正确填充到编辑器中

## Screenshots/Videos / 截图/视频
<!-- 可添加截图展示同步效果 -->

## Additional Notes / 补充说明
- 此功能需要用户已登录博客园账号
- 支持博客园的标准 Markdown 编辑器