### PR TITLE
fix: isLogin sign

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -337,6 +337,11 @@ async function checkLoginByCookie(platformId, config) {
           console.log(`[COSE] ${platformId} 使用通用解析逻辑`)
           const info = config.parseUserInfo(html)
           if (info) {
+            // 允许解析函数显式返回未登录状态
+            if (info.loggedIn === false) {
+              console.log(`[COSE] ${platformId} 解析结果判定为未登录`)
+              return { loggedIn: false }
+            }
             if (info.username) username = info.username
             if (info.avatar) avatar = info.avatar
             // 如果解析出了 userId，保存到全局存储


### PR DESCRIPTION
## Summary / 概述
<!-- Provide a brief description of the changes in this PR -->
<!-- 简要描述此 PR 中的更改 -->
This PR fixes a bug in the 51CTO platform integration where users were incorrectly identified as logged in even when they were not. It improves the login detection logic to avoid false positives from `data-uid` attributes belonging to other authors and ensures the "Login" link is correctly displayed.

## Related Issue / 关联 Issue
<!-- Link to the related issue(s) -->
<!-- 链接到相关的 issue -->
Closes #37 

## Type of Change / 更改类型
<!-- Mark the relevant option with an "x" -->
<!-- 用 "x" 标记相关选项 -->
- [x] Bug fix / 修复 Bug (non-breaking change that fixes an issue / 修复问题的非破坏性更改)
- [ ] New feature / 新功能 (non-breaking change that adds functionality / 添加功能的非破坏性更改)
- [ ] Breaking change / 破坏性更改 (fix or feature that would cause existing functionality to not work as expected / 会导致现有功能无法正常工作的修复或功能)
- [ ] Documentation update / 文档更新
- [ ] Performance improvement / 性能优化
- [ ] Code refactoring / 代码重构
- [ ] Other / 其他 (please describe / 请描述):


## Changes Made / 更改内容
<!-- Describe the specific changes made in this PR -->
<!-- 描述此 PR 中的具体更改 -->
- Improved `parseUserInfo` logic in `cose/src/platforms/cto51.js` to strictly detect "Not Logged In" states (e.g., checking for "Login" links or `isLogin` global variable).
- Restrict `userId` extraction to the header/user profile area to prevent falsely matching `data-uid` from the article feed.
- Update `cose/src/background.js` to allow `parseUserInfo` to explicitly return `{ loggedIn: false }` to override default cookie checks.
- Re-added `loginUrl` to 51CTO configuration.


## Implementation Details / 实现细节
<!-- Provide technical details about your implementation -->
<!-- 提供实现的技术细节 -->

**Key Changes / 主要更改:**
- **Strict Logout Detection**: Added checks for `html.match(/<a[^>]*>登录<\/a>/)` and `isLogin` variable.
- **Contextual ID Matching**: The regex for extracting `userId` is now more specific to the user profile context, avoiding random images in the content stream.
- **Control Flow**: `background.js` now respects an explicit `loggedIn: false` return from platform parsers.

**Technical Notes / 技术说明:**
- 51CTO pages contain many `data-uid` attributes for post authors. The previous regex was too broad, causing the plugin to pick up the first author's ID as the current user's ID when no session headers were present.


## Testing / 测试
<!-- Describe the testing you performed -->
<!-- 描述您执行的测试 -->

### Testing Checklist / 测试清单
- [x] I have tested this code locally / 我已在本地测试此代码
- [x] All existing tests pass / 所有现有测试通过
- [ ] I have added tests for new functionality / 我已为新功能添加测试
- [x] I have tested on the affected platform(s) / 我已在受影响的平台上测试
- [x] I have verified the changes work in the target browser(s) / 我已验证更改在目标浏览器中有效

### Manual Testing Steps / 手动测试步骤
1. Open Chrome and ensure you are logged out of `https://blog.51cto.com/`.
2. Open the COSE extension publish dialog.
3. Verify that the 51CTO item shows a "Login" link instead of a username like `User_123456`.
4. Click the "Login" link and verify it redirects to the login page.
5. Log in to 51CTO and reopen the extension to verify the correct username is displayed.


## Screenshots/Videos / 截图/视频
<!-- If applicable, add screenshots or videos to demonstrate the changes -->
<!-- 如适用，请添加截图或视频来展示更改 -->
(Screenshots can be added here)


## Reviewer Checklist / 审阅者清单
<!-- For reviewers to verify before merging -->
<!-- 供审阅者在合并前验证 -->
- [ ] Code follows the project's style guidelines / 代码遵循项目的风格指南
- [ ] Changes are well-documented / 更改有良好的文档说明
- [ ] No breaking changes or clearly documented if present / 无破坏性更改，或已清楚记录
- [ ] Security implications have been considered / 已考虑安全影响
- [ ] Performance impact has been evaluated / 已评估性能影响
- [ ] All discussions have been resolved / 所有讨论已解决


## Additional Notes / 补充说明
<!-- Any additional information that reviewers should know -->
<!-- 审阅者需要了解的其他信息 -->
The `uid` cookie was removed from the check list in `cto51.js` as it persisted even after logout, causing misleading "logged in" status judgments.
