### PR TITLE
feat: jianshu platform sync

### DIFF
--- a/src/inject.js
+++ b/src/inject.js
@@ -73,6 +73,7 @@
     { id: 'oschina', name: 'OSChina', icon: 'https://wsrv.nl/?url=static.oschina.net/new-osc/img/favicon.ico', title: '开源中国', type: 'oschina' },
     { id: 'cto51', name: '51CTO', icon: 'https://www.google.com/s2/favicons?domain=51cto.com&sz=32', title: '51CTO', type: 'cto51' },
     { id: 'infoq', name: 'InfoQ', icon: 'https://static001.infoq.cn/static/write/img/write-favicon.jpg', title: 'InfoQ', type: 'infoq' },
+    { id: 'jianshu', name: 'Jianshu', icon: 'https://www.jianshu.com/favicon.ico', title: '简书', type: 'jianshu' },
   ]
 
   // 暴露 $cose 全局对象

--- a/src/platforms/index.js
+++ b/src/platforms/index.js
@@ -2,6 +2,7 @@
 import { OSChinaPlatform, OSChinaLoginConfig } from './oschina.js'
 import { CTO51Platform, CTO51LoginConfig } from './cto51.js'
 import { InfoQPlatform, InfoQLoginConfig } from './infoq.js'
+import { JianshuPlatform, JianshuLoginConfig } from './jianshu.js'
 // 这里可以继续导入其他平台的配置
 // import { CSDNPlatform, CSDNLoginConfig } from './csdn.js'
 
@@ -142,6 +143,7 @@ const PLATFORMS = [
   OSChinaPlatform,
   CTO51Platform,
   InfoQPlatform,
+  JianshuPlatform,
 ]
 
 // 合并登录检测配置
@@ -150,6 +152,7 @@ const LOGIN_CHECK_CONFIG = {
   [OSChinaPlatform.id]: OSChinaLoginConfig,
   [CTO51Platform.id]: CTO51LoginConfig,
   [InfoQPlatform.id]: InfoQLoginConfig,
+  [JianshuPlatform.id]: JianshuLoginConfig,
 }
 
 // 根据 hostname 获取平台填充函数
@@ -164,6 +167,7 @@ function getPlatformFiller(hostname) {
   if (hostname.includes('oschina.net')) return 'oschina'
   if (hostname.includes('51cto.com')) return 'cto51'
   if (hostname.includes('infoq.cn')) return 'infoq'
+  if (hostname.includes('jianshu.com')) return 'jianshu'
   return 'generic'
 }
 

--- a/src/platforms/jianshu.js
+++ b/src/platforms/jianshu.js
@@ -1,0 +1,64 @@
+// 简书平台配置
+const JianshuPlatform = {
+  id: 'jianshu',
+  name: 'Jianshu',
+  icon: 'https://www.jianshu.com/favicon.ico',
+  url: 'https://www.jianshu.com',
+  publishUrl: 'https://www.jianshu.com/writer',
+  title: '简书',
+  type: 'jianshu',
+}
+
+// 简书登录检测配置
+const JianshuLoginConfig = {
+  api: 'https://www.jianshu.com/author/current_user',
+  method: 'GET',
+  checkLogin: (response) => response?.id,
+  getUserInfo: (response) => ({
+    username: response?.nickname,
+    avatar: response?.avatar,
+  }),
+}
+
+// 简书内容填充函数
+async function fillJianshuContent(content, waitFor, setInputValue) {
+  const { title, body, markdown } = content
+  const contentToFill = markdown || body || ''
+
+  // 填充标题 - 简书使用 input._24i7u，需要使用 native setter
+  const titleInput = await waitFor('input._24i7u, input[class*="title"]')
+  if (titleInput) {
+    titleInput.focus()
+    const inputSetter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value').set
+    inputSetter.call(titleInput, title)
+    titleInput.dispatchEvent(new InputEvent('input', { bubbles: true, data: title, inputType: 'insertText' }))
+    titleInput.dispatchEvent(new Event('change', { bubbles: true }))
+    titleInput.dispatchEvent(new Event('blur', { bubbles: true }))
+    console.log('[COSE] 简书标题填充成功')
+  } else {
+    console.log('[COSE] 简书未找到标题输入框')
+  }
+
+  // 等待编辑器加载
+  await new Promise(resolve => setTimeout(resolve, 500))
+
+  // 简书使用 textarea#arthur-editor 作为 Markdown 编辑器
+  const editor = document.querySelector('#arthur-editor') || document.querySelector('textarea._3swFR')
+  if (editor) {
+    editor.focus()
+    const textareaSetter = Object.getOwnPropertyDescriptor(window.HTMLTextAreaElement.prototype, 'value').set
+    textareaSetter.call(editor, contentToFill)
+    editor.dispatchEvent(new InputEvent('input', { bubbles: true, data: contentToFill, inputType: 'insertText' }))
+    editor.dispatchEvent(new Event('change', { bubbles: true }))
+    console.log('[COSE] 简书内容填充成功')
+  } else {
+    console.log('[COSE] 简书未找到编辑器')
+  }
+}
+
+// 导出
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = { JianshuPlatform, JianshuLoginConfig, fillJianshuContent }
+}
+
+export { JianshuPlatform, JianshuLoginConfig, fillJianshuContent }


### PR DESCRIPTION
## Summary / 概述

Add support for Jianshu (简书) platform, enabling users to sync articles to Jianshu with automatic article creation and content filling.

## Related Issue / 关联 Issue

Closes #42 

## Type of Change / 更改类型

- [ ] Bug fix / 修复 Bug
- [x] New feature / 新功能 (non-breaking change that adds functionality)
- [ ] Breaking change / 破坏性更改
- [ ] Documentation update / 文档更新
- [ ] Performance improvement / 性能优化
- [ ] Code refactoring / 代码重构
- [ ] Other / 其他

## Changes Made / 更改内容

- Added new platform configuration file `src/platforms/jianshu.js`
- Registered Jianshu platform in `src/platforms/index.js`
- Added Jianshu to frontend platform list in `src/inject.js`
- Implemented article creation and content filling logic in `src/background.js`

## Implementation Details / 实现细节

**Key Changes / 主要更改:**

- **Login Detection**: Uses `/author/current_user` API to check login status and retrieve user info (nickname, avatar)
- **Article Creation Flow**: 
  1. Fetches user's notebook list via `GET /author/notebooks`
  2. Creates new article via `POST /author/notes` with the first notebook
  3. Navigates to the new article's editor page
- **Content Filling**: Uses native setter to properly set values in React-controlled inputs
  - Title input: `input._24i7u`
  - Content editor: `textarea#arthur-editor` (Markdown editor)

**Technical Notes / 技术说明:**

- Jianshu uses React for state management, requiring native setter approach (`Object.getOwnPropertyDescriptor`) to properly trigger state updates
- The platform requires creating a new article before filling content, similar to InfoQ's implementation
- Article creation requires a valid `notebook_id`, which is obtained from the user's notebook list

## Testing / 测试

### Testing Checklist / 测试清单

- [x] I have tested this code locally
- [ ] All existing tests pass
- [ ] I have added tests for new functionality
- [x] I have tested on the affected platform(s)
- [x] I have verified the changes work in the target browser(s)

### Manual Testing Steps / 手动测试步骤

1. Load the extension in Chrome
2. Navigate to the MD editor (localhost:5173/md/)
3. Select Jianshu from the platform list
4. Verify login status is correctly detected
5. Click sync to create a new article on Jianshu
6. Verify title and markdown content are correctly filled

## Screenshots/Videos / 截图/视频

N/A

## Reviewer Checklist / 审阅者清单

- [ ] Code follows the project's style guidelines
- [ ] Changes are well-documented
- [ ] No breaking changes or clearly documented if present
- [ ] Security implications have been considered
- [ ] Performance impact has been evaluated
- [ ] All discussions have been resolved

## Additional Notes / 补充说明

- Jianshu's class names (e.g., `._24i7u`, `._3swFR`) are minified and may change in future updates. Fallback selectors are provided where possible.
- The implementation uses the first notebook in the user's list by default. Future enhancement could allow users to select a specific notebook.