### PR TITLE
fix: segmentfault icon cors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,10 @@
 # misc
 .DS_Store
 *.zip
+.vscode
+.idea
+.cursor
+.fleet
+.zed
+.windsurf
+.kiro

--- a/src/inject.js
+++ b/src/inject.js
@@ -68,7 +68,7 @@
     { id: 'wechat', name: 'WeChat', icon: 'https://res.wx.qq.com/a/wx_fed/assets/res/NTI4MWU5.ico', title: '微信公众号', type: 'wechat' },
     { id: 'zhihu', name: 'Zhihu', icon: 'https://static.zhihu.com/heifetz/favicon.ico', title: '知乎', type: 'zhihu' },
     { id: 'toutiao', name: 'Toutiao', icon: 'https://sf3-cdn-tos.toutiaostatic.com/obj/eden-cn/uhbfnupkbps/toutiao_favicon.ico', title: '今日头条', type: 'toutiao' },
-    { id: 'segmentfault', name: 'SegmentFault', icon: 'https://youke2.picui.cn/s1/2025/12/21/6947b2935a41e.ico', title: '思否', type: 'segmentfault' },
+    { id: 'segmentfault', name: 'SegmentFault', icon: 'https://www.google.com/s2/favicons?domain=segmentfault.com&sz=32', title: '思否', type: 'segmentfault' },
     { id: 'cnblogs', name: 'Cnblogs', icon: 'https://www.cnblogs.com/favicon.ico', title: '博客园', type: 'cnblogs' },
     { id: 'oschina', name: 'OSChina', icon: 'https://wsrv.nl/?url=static.oschina.net/new-osc/img/favicon.ico', title: '开源中国', type: 'oschina' },
     { id: 'cto51', name: '51CTO', icon: 'https://www.google.com/s2/favicons?domain=51cto.com&sz=32', title: '51CTO', type: 'cto51' },

--- a/src/platforms/index.js
+++ b/src/platforms/index.js
@@ -56,7 +56,7 @@ const BASE_PLATFORMS = [
   {
     id: 'segmentfault',
     name: 'SegmentFault',
-    icon: 'https://static.segmentfault.com/main_site_next/prod/favicon.ico',
+    icon: 'https://www.google.com/s2/favicons?domain=segmentfault.com&sz=32',
     url: 'https://segmentfault.com',
     publishUrl: 'https://segmentfault.com/write',
     title: '思否',

--- a/src/platforms/segmentfault.js
+++ b/src/platforms/segmentfault.js
@@ -2,7 +2,7 @@
 const SegmentFaultPlatform = {
   id: 'segmentfault',
   name: 'SegmentFault',
-  icon: 'https://static.segmentfault.com/main_site_next/prod/favicon.ico',
+  icon: 'https://www.google.com/s2/favicons?domain=segmentfault.com&sz=32',
   url: 'https://segmentfault.com',
   publishUrl: 'https://segmentfault.com/write',
   title: '思否',


### PR DESCRIPTION
## Summary
Fix SegmentFault platform icon failing to load due to CORS policy restrictions.

## Related Issue
Closes #46 

## Type of Change
- [x] Bug fix

## Changes Made
- Replace SegmentFault favicon URL with Google Favicon service

## Implementation Details

**Key Changes:**
- Use Google Favicon API (`https://www.google.com/s2/favicons?domain=segmentfault.com&sz=32`) instead of the original favicon URL

**Technical Notes:**
- Original favicon URL (`static.segmentfault.com/main_site_next/prod/favicon.ico`) has CORS restrictions preventing the extension from loading the icon
- Google Favicon service supports cross-origin requests and provides reliable icon fetching

## Testing

### Testing Checklist
- [x] I have tested this code locally
- [x] I have tested on the affected platform(s)
- [x] I have verified the changes work in the target browser(s)

### Manual Testing Steps
1. Load the extension
2. Check if SegmentFault icon displays correctly in the platform list
3. Verify icon clarity (32x32)

## Additional Notes
Google Favicon service is a widely-used solution for cross-origin icon fetching.