### PR TITLE
feat: sspai platform sync

### DIFF
--- a/src/inject.js
+++ b/src/inject.js
@@ -78,6 +78,7 @@
     { id: 'wangyihao', name: 'Wangyihao', icon: 'https://static.ws.126.net/163/f2e/news/yxybd_pc/resource/static/share-icon.png', title: '网易号', type: 'wangyihao', url: 'https://mp.163.com/' },
     { id: 'tencentcloud', name: 'TencentCloud', icon: 'https://cloudcache.tencent-cloud.com/qcloud/favicon.ico', title: '腾讯云开发者社区', type: 'tencentcloud', url: 'https://cloud.tencent.com/developer' },
     { id: 'medium', name: 'Medium', icon: 'https://miro.medium.com/v2/resize:fill:32:32/1*sHhtYhaCe2Uc3IU0IgKwIQ.png', title: 'Medium', type: 'medium', url: 'https://medium.com' },
+    { id: 'sspai', name: 'Sspai', icon: 'https://cdn-static.sspai.com/favicon/sspai.ico', title: '少数派', type: 'sspai', url: 'https://sspai.com' },
   ]
 
   // 暴露 $cose 全局对象
@@ -174,13 +175,14 @@
         // 开始新的同步批次，将所有 tab 放入一个 group
         await sendMessage('START_SYNC_BATCH', {})
 
-        // 检查是否需要同步到微信公众号或百家号或网易号或 Medium（需要使用剪贴板 HTML）
+        // 检查是否需要同步到微信公众号或百家号或网易号或 Medium 或少数派（需要使用剪贴板 HTML）
         const hasWechat = selectedAccounts.some(a => (a.uid || a.type) === 'wechat')
         const hasBaijiahao = selectedAccounts.some(a => (a.uid || a.type) === 'baijiahao')
         const hasWangyihao = selectedAccounts.some(a => (a.uid || a.type) === 'wangyihao')
         const hasMedium = selectedAccounts.some(a => (a.uid || a.type) === 'medium')
+        const hasSspai = selectedAccounts.some(a => (a.uid || a.type) === 'sspai')
         let clipboardHtmlContent = null
-        if (hasWechat || hasBaijiahao || hasWangyihao || hasMedium) {
+        if (hasWechat || hasBaijiahao || hasWangyihao || hasMedium || hasSspai) {
           // 先点击复制按钮，将带样式的内容复制到剪贴板
           const copyBtn = document.querySelector('.copy-btn') ||
             document.querySelector('button[class*="copy"]') ||
@@ -224,8 +226,8 @@
                 markdown: post.markdown,
                 thumb: post.thumb,
                 desc: post.desc,
-                // 微信公众号、百家号、网易号和 Medium 使用剪贴板中带样式的 HTML
-                wechatHtml: (platformId === 'wechat' || platformId === 'baijiahao' || platformId === 'wangyihao' || platformId === 'medium') ? clipboardHtmlContent : null,
+                // 微信公众号、百家号、网易号、Medium 和少数派使用剪贴板中带样式的 HTML
+                wechatHtml: (platformId === 'wechat' || platformId === 'baijiahao' || platformId === 'wangyihao' || platformId === 'medium' || platformId === 'sspai') ? clipboardHtmlContent : null,
               },
             })
 

--- a/src/platforms/index.js
+++ b/src/platforms/index.js
@@ -7,6 +7,7 @@ import { BaijiahaoPlatform, BaijiahaoLoginConfig } from './baijiahao.js'
 import { WangyihaoPlatform, WangyihaoLoginConfig } from './wangyihao.js'
 import { TencentCloudPlatform, TencentCloudLoginConfig } from './tencentcloud.js'
 import { MediumPlatform, MediumLoginConfig } from './medium.js'
+import { SspaiPlatform, SspaiLoginConfig } from './sspai.js'
 // 这里可以继续导入其他平台的配置
 // import { CSDNPlatform, CSDNLoginConfig } from './csdn.js'
 
@@ -152,6 +153,7 @@ const PLATFORMS = [
   WangyihaoPlatform,
   TencentCloudPlatform,
   MediumPlatform,
+  SspaiPlatform,
 ]
 
 // 合并登录检测配置
@@ -165,6 +167,7 @@ const LOGIN_CHECK_CONFIG = {
   [WangyihaoPlatform.id]: WangyihaoLoginConfig,
   [TencentCloudPlatform.id]: TencentCloudLoginConfig,
   [MediumPlatform.id]: MediumLoginConfig,
+  [SspaiPlatform.id]: SspaiLoginConfig,
 }
 
 // 根据 hostname 获取平台填充函数
@@ -184,6 +187,7 @@ function getPlatformFiller(hostname) {
   if (hostname.includes('mp.163.com')) return 'wangyihao'
   if (hostname.includes('cloud.tencent.com')) return 'tencentcloud'
   if (hostname.includes('medium.com')) return 'medium'
+  if (hostname.includes('sspai.com')) return 'sspai'
   return 'generic'
 }
 

--- a/src/platforms/sspai.js
+++ b/src/platforms/sspai.js
@@ -1,0 +1,66 @@
+// 少数派平台配置
+const SspaiPlatform = {
+  id: 'sspai',
+  name: 'Sspai',
+  icon: 'https://cdn-static.sspai.com/favicon/sspai.ico',
+  url: 'https://sspai.com',
+  publishUrl: 'https://sspai.com/write',
+  title: '少数派',
+  type: 'sspai',
+}
+
+// 少数派登录检测配置
+const SspaiLoginConfig = {
+  useCookie: true,
+  cookieUrl: 'https://sspai.com',
+  cookieNames: ['sspai_jwt_token'],
+  // 少数派需要特殊处理，在 background.js 中单独实现
+  // 使用 /api/v1/user/info/get API 获取用户信息
+}
+
+// 少数派内容填充函数（备用，主要使用剪贴板方式）
+async function fillSspaiContent(content, waitFor, setInputValue) {
+  const { title, body, markdown } = content
+  const contentToFill = markdown || body || ''
+
+  // 1. 填充标题 - 少数派使用 textbox
+  await new Promise(resolve => setTimeout(resolve, 1000))
+  
+  const titleInput = document.querySelector('textarea[placeholder*="标题"]') ||
+    document.querySelector('input[placeholder*="标题"]')
+
+  if (titleInput) {
+    titleInput.focus()
+    // 使用 native setter 来绕过 React/Vue 的受控组件
+    const nativeSetter = Object.getOwnPropertyDescriptor(window.HTMLTextAreaElement.prototype, 'value').set ||
+      Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value').set
+    nativeSetter.call(titleInput, title)
+    // 触发事件
+    titleInput.dispatchEvent(new InputEvent('input', { bubbles: true, data: title, inputType: 'insertText' }))
+    titleInput.dispatchEvent(new Event('change', { bubbles: true }))
+    titleInput.dispatchEvent(new Event('blur', { bubbles: true }))
+    console.log('[COSE] 少数派标题填充成功')
+  } else {
+    console.log('[COSE] 少数派未找到标题输入框')
+  }
+
+  // 2. 等待编辑器加载
+  await new Promise(resolve => setTimeout(resolve, 1500))
+
+  // 3. 填充正文内容
+  // 少数派使用 ProseMirror 富文本编辑器
+  const editor = document.querySelector('.ProseMirror') ||
+    document.querySelector('[contenteditable="true"]')
+
+  if (editor) {
+    editor.focus()
+    editor.innerHTML = contentToFill.replace(/\n/g, '<br>')
+    editor.dispatchEvent(new Event('input', { bubbles: true }))
+    console.log('[COSE] 少数派编辑器填充成功')
+  } else {
+    console.log('[COSE] 少数派未找到编辑器元素')
+  }
+}
+
+// 导出
+export { SspaiPlatform, SspaiLoginConfig, fillSspaiContent }


### PR DESCRIPTION
## Summary / 概述

Add support for Sspai (少数派) platform in the COSE browser extension, enabling users to sync articles directly to Sspai. This update includes a new modular platform configuration, JWT-based login detection with real user profile retrieval, and clipboard-based content filling using ProseMirror paste events.

## Related Issue / 关联 Issue

Closes #67 

## Type of Change / 更改类型

- [ ] Bug fix / 修复 Bug (non-breaking change that fixes an issue / 修复问题的非破坏性更改)
- [x] New feature / 新功能 (non-breaking change that adds functionality / 添加功能的非破坏性更改)
- [ ] Breaking change / 破坏性更改 (fix or feature that would cause existing functionality to not work as expected / 会导致现有功能无法正常工作的修复或功能)
- [ ] Documentation update / 文档更新
- [ ] Performance improvement / 性能优化
- [ ] Code refactoring / 代码重构
- [ ] Other / 其他 (please describe / 请描述):

## Changes Made / 更改内容

- Created `src/platforms/sspai.js` with platform configuration and login detection config
- Added Sspai to platform registry in `src/platforms/index.js`
- Added Sspai to frontend platform list in `src/inject.js`
- Added clipboard HTML support for Sspai (same pattern as WeChat, Baijiahao, Wangyihao)
- Implemented JWT-based login detection in `src/background.js`
- Implemented clipboard-based content sync in `src/background.js`

## Implementation Details / 实现细节

**Key Changes / 主要更改:**

- **Platform Configuration:** Added Sspai with official favicon, publish URL (`https://sspai.com/write`), and platform metadata
- **Login Detection:** Uses `sspai_jwt_token` cookie to authenticate API requests to `https://sspai.com/api/v1/user/info/get`
- **Content Sync:** Uses clipboard-based approach (same as WeChat/Baijiahao/Wangyihao) - copies styled HTML from editor and pastes via ClipboardEvent

**Technical Notes / 技术说明:**

- Sspai API requires `Authorization: Bearer <token>` header, where token is read from `sspai_jwt_token` cookie
- Title input uses native setter to bypass Vue's controlled component pattern
- Content is pasted into ProseMirror editor via ClipboardEvent with `text/html` data
- Sspai CDN has no CORS restrictions, so avatar URLs can be used directly without proxy

## Testing / 测试

### Testing Checklist / 测试清单

- [x] I have tested this code locally / 我已在本地测试此代码
- [ ] All existing tests pass / 所有现有测试通过
- [ ] I have added tests for new functionality / 我已为新功能添加测试
- [x] I have tested on the affected platform(s) / 我已在受影响的平台上测试
- [x] I have verified the changes work in the target browser(s) / 我已验证更改在目标浏览器中有效

### Manual Testing Steps / 手动测试步骤

1. Install/reload the COSE extension in Chrome
2. Log in to Sspai (https://sspai.com/) in the browser
3. Open the Markdown editor and click "发布" (Publish) button
4. Verify Sspai shows the correct username and avatar in the platform list
5. Select Sspai and click "确定" (Confirm) to sync
6. Verify the article title and content are correctly filled in the Sspai editor

## Screenshots/Videos / 截图/视频

<!-- Add screenshots showing: -->
<!-- 1. Sspai appearing in platform list with correct login status -->
<!-- 2. Content successfully synced to Sspai editor -->

## Reviewer Checklist / 审阅者清单

- [ ] Code follows the project's style guidelines / 代码遵循项目的风格指南
- [ ] Changes are well-documented / 更改有良好的文档说明
- [ ] No breaking changes or clearly documented if present / 无破坏性更改，或已清楚记录
- [ ] Security implications have been considered / 已考虑安全影响
- [ ] Performance impact has been evaluated / 已评估性能影响
- [ ] All discussions have been resolved / 所有讨论已解决

## Additional Notes / 补充说明

Sspai (少数派) is a popular high-quality tech lifestyle content platform in China, focusing on productivity tools, digital life, and in-depth tech reviews. This integration follows the same clipboard-based sync pattern used for WeChat, Baijiahao, and Wangyihao platforms.