### PR TITLE
feat: bili platform sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ _**C**reate **O**nce **S**ync **E**verywhere_
 - Medium
 - 少数派
 - 搜狐号
+- B站专栏
 
 更多想要添加的平台欢迎提 [Issue](https://github.com/doocs/cose/issues) ！
 

--- a/src/inject.js
+++ b/src/inject.js
@@ -80,6 +80,7 @@
     { id: 'medium', name: 'Medium', icon: 'https://miro.medium.com/v2/resize:fill:32:32/1*sHhtYhaCe2Uc3IU0IgKwIQ.png', title: 'Medium', type: 'medium', url: 'https://medium.com' },
     { id: 'sspai', name: 'Sspai', icon: 'https://cdn-static.sspai.com/favicon/sspai.ico', title: '少数派', type: 'sspai', url: 'https://sspai.com' },
     { id: 'sohu', name: 'Sohu', icon: 'https://www.google.com/s2/favicons?domain=sohu.com&sz=32', title: '搜狐号', type: 'sohu', url: 'https://mp.sohu.com' },
+    { id: 'bilibili', name: 'Bilibili', icon: 'https://www.bilibili.com/favicon.ico', title: 'B站专栏', type: 'bilibili', url: 'https://member.bilibili.com/article-text/home?newEditor=-1' },
   ]
 
   // 暴露 $cose 全局对象
@@ -176,14 +177,15 @@
         // 开始新的同步批次，将所有 tab 放入一个 group
         await sendMessage('START_SYNC_BATCH', {})
 
-        // 检查是否需要同步到微信公众号或百家号或网易号或 Medium 或少数派（需要使用剪贴板 HTML）
+        // 检查是否需要同步到微信公众号或百家号或网易号或 Medium 或少数派或B站专栏（需要使用剪贴板 HTML）
         const hasWechat = selectedAccounts.some(a => (a.uid || a.type) === 'wechat')
         const hasBaijiahao = selectedAccounts.some(a => (a.uid || a.type) === 'baijiahao')
         const hasWangyihao = selectedAccounts.some(a => (a.uid || a.type) === 'wangyihao')
         const hasMedium = selectedAccounts.some(a => (a.uid || a.type) === 'medium')
         const hasSspai = selectedAccounts.some(a => (a.uid || a.type) === 'sspai')
+        const hasBilibili = selectedAccounts.some(a => (a.uid || a.type) === 'bilibili')
         let clipboardHtmlContent = null
-        if (hasWechat || hasBaijiahao || hasWangyihao || hasMedium || hasSspai) {
+        if (hasWechat || hasBaijiahao || hasWangyihao || hasMedium || hasSspai || hasBilibili) {
           // 先点击复制按钮，将带样式的内容复制到剪贴板
           const copyBtn = document.querySelector('.copy-btn') ||
             document.querySelector('button[class*="copy"]') ||
@@ -227,8 +229,8 @@
                 markdown: post.markdown,
                 thumb: post.thumb,
                 desc: post.desc,
-                // 微信公众号、百家号、网易号、Medium 和少数派使用剪贴板中带样式的 HTML
-                wechatHtml: (platformId === 'wechat' || platformId === 'baijiahao' || platformId === 'wangyihao' || platformId === 'medium' || platformId === 'sspai') ? clipboardHtmlContent : null,
+                // 微信公众号、百家号、网易号、Medium、少数派和B站专栏使用剪贴板中带样式的 HTML
+                wechatHtml: (platformId === 'wechat' || platformId === 'baijiahao' || platformId === 'wangyihao' || platformId === 'medium' || platformId === 'sspai' || platformId === 'bilibili') ? clipboardHtmlContent : null,
               },
             })
 

--- a/src/platforms/bilibili.js
+++ b/src/platforms/bilibili.js
@@ -1,0 +1,31 @@
+// B站专栏平台配置（使用旧版编辑器，基于 UEditor）
+// 同步方式：使用 UEditor execCommand('inserthtml') 插入 HTML
+const BilibiliPlatform = {
+  id: 'bilibili',
+  name: 'Bilibili',
+  icon: 'https://www.bilibili.com/favicon.ico',
+  url: 'https://member.bilibili.com',
+  publishUrl: 'https://member.bilibili.com/article-text/home?newEditor=-1',
+  title: 'B站专栏',
+  type: 'bilibili',
+}
+
+// B站专栏登录检测配置
+const BilibiliLoginConfig = {
+  api: 'https://api.bilibili.com/x/web-interface/nav',
+  method: 'GET',
+  checkLogin: (data) => data?.code === 0 && data?.data?.isLogin === true,
+  getUserInfo: (data) => ({
+    username: data?.data?.uname || '',
+    avatar: data?.data?.face || '',
+  }),
+}
+
+// B站专栏内容填充函数（由 background.js 处理）
+// 使用 UEditor 的 execCommand('inserthtml') 方法插入 HTML 内容
+async function fillBilibiliContent(content, waitFor, setInputValue) {
+  console.log('[COSE] B站专栏填充由 background.js 处理')
+}
+
+// 导出
+export { BilibiliPlatform, BilibiliLoginConfig, fillBilibiliContent }

--- a/src/platforms/index.js
+++ b/src/platforms/index.js
@@ -16,6 +16,7 @@ import { TencentCloudPlatform, TencentCloudLoginConfig } from './tencentcloud.js
 import { MediumPlatform, MediumLoginConfig } from './medium.js'
 import { SspaiPlatform, SspaiLoginConfig } from './sspai.js'
 import { SohuPlatform, SohuLoginConfig } from './sohu.js'
+import { BilibiliPlatform, BilibiliLoginConfig } from './bilibili.js'
 
 // 合并平台配置
 const PLATFORMS = [
@@ -36,6 +37,7 @@ const PLATFORMS = [
   MediumPlatform,
   SspaiPlatform,
   SohuPlatform,
+  BilibiliPlatform,
 ]
 
 // 合并登录检测配置
@@ -57,6 +59,7 @@ const LOGIN_CHECK_CONFIG = {
   [MediumPlatform.id]: MediumLoginConfig,
   [SspaiPlatform.id]: SspaiLoginConfig,
   [SohuPlatform.id]: SohuLoginConfig,
+  [BilibiliPlatform.id]: BilibiliLoginConfig,
 }
 
 // 根据 hostname 获取平台填充函数
@@ -78,6 +81,7 @@ function getPlatformFiller(hostname) {
   if (hostname.includes('medium.com')) return 'medium'
   if (hostname.includes('sspai.com')) return 'sspai'
   if (hostname.includes('mp.sohu.com')) return 'sohu'
+  if (hostname.includes('member.bilibili.com')) return 'bilibili'
   return 'generic'
 }
 


### PR DESCRIPTION
## Summary / 概述
Add support for Bilibili Read (B站专栏) platform, allowing users to sync articles to Bilibili's long-form content section.

## Related Issue / 关联 Issue
Closes #76 

## Type of Change / 更改类型
- [ ] Bug fix / 修复 Bug
- [x] New feature / 新功能
- [ ] Breaking change / 破坏性更改
- [ ] Documentation update / 文档更新
- [ ] Performance improvement / 性能优化
- [ ] Code refactoring / 代码重构
- [ ] Other / 其他

## Changes Made / 更改内容
- Added `src/platforms/bilibili.js` with platform config and login detection
- Added Bilibili to platform list in `src/platforms/index.js`
- Added Bilibili to inject.js platform array
- Added sync logic for Bilibili Read in `src/background.js`
- Added Bilibili host permissions in `manifest.json`

## Implementation Details / 实现细节

**Key Changes / 主要更改:**
- Uses the legacy editor URL (`?newEditor=-1`) which is based on UEditor
- Login detection via Bilibili's nav API (`/x/web-interface/nav`)
- Content sync using UEditor's `execCommand('inserthtml')` method

**Technical Notes / 技术说明:**
- Bilibili Read has two editors: new (Quill-based) and legacy (UEditor-based)
- The legacy editor provides better compatibility for HTML content injection
- Using `execCommand('inserthtml')` instead of `setContent()` ensures proper word count update

## Testing / 测试

### Testing Checklist / 测试清单
- [x] I have tested this code locally
- [ ] All existing tests pass
- [ ] I have added tests for new functionality
- [x] I have tested on the affected platform(s)
- [x] I have verified the changes work in the target browser(s)

### Manual Testing Steps / 手动测试步骤
1. Load the extension in Chrome
2. Login to Bilibili account
3. Open md.doocs.org and create an article
4. Click sync and select "B站专栏"
5. Verify title and content are filled correctly with word count displayed

## Screenshots/Videos / 截图/视频
N/A

## Additional Notes / 补充说明
The implementation uses Bilibili's legacy UEditor-based editor for better HTML content compatibility.