### PR TITLE
feat: volcengine articles sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ _**C**reate **O**nce **S**ync **E**verywhere_
 > | A | 阿里云社区 |
 > | B | B站专栏、百度云千帆、百家号、博客园 |
 > | C | CSDN |
-> | H | 华为开发者文章、华为云博客 |
+> | H | 华为开发者文章、华为云博客、火山引擎社区 |
 > | I | InfoQ |
 > | J | 简书、掘金、今日头条 |
 > | K | 开源中国 |
@@ -111,9 +111,12 @@ _**C**reate **O**nce **S**ync **E**verywhere_
   <img src="https://cdn.jsdelivr.net/npm/@lobehub/icons-static-png/light/huawei-text.png" alt="华为开发者文章" width="100" height="60" />
   <img src="https://cdn.jsdelivr.net/npm/@lobehub/icons-static-png/dark/baiducloud-color.png" alt="百度云千帆" width="30" height="60" />
   <img src="https://cdn.jsdelivr.net/npm/@lobehub/icons-static-png/light/baiducloud-text.png" alt="百度云千帆" width="110" height="60" />
-  <img src="https://cdn.simpleicons.org/alipay/1677FF" alt="支付宝开放平台" width="30" height="50" />
+  <br />
+  <!-- <img src="https://cdn.simpleicons.org/alipay/1677FF" alt="支付宝开放平台" width="30" height="50" /> -->
   <img src="https://cdn.jsdelivr.net/npm/@lobehub/icons-static-png/dark/modelscope-color.png" alt="魔搭社区" width="36" height="60" />
   <img src="https://cdn.jsdelivr.net/npm/@lobehub/icons-static-png/light/modelscope-text.png" alt="魔搭社区" width="160" height="60" />
+  <img src="https://cdn.jsdelivr.net/npm/@lobehub/icons-static-png/dark/volcengine-color.png" alt="火山引擎" width="36" height="60" />
+  <img src="https://cdn.jsdelivr.net/npm/@lobehub/icons-static-png/light/volcengine-text.png" alt="火山引擎" width="90" height="60" />
 </div>
 </div>
 

--- a/manifest.json
+++ b/manifest.json
@@ -44,7 +44,8 @@
     "https://*.twitter.com/*",
     "https://qianfan.cloud.baidu.com/*",
     "https://*.alipay.com/*",
-    "https://*.modelscope.cn/*"
+    "https://*.modelscope.cn/*",
+    "https://*.volcengine.com/*"
   ],
   "action": {
     "default_icon": {

--- a/src/inject.js
+++ b/src/inject.js
@@ -89,6 +89,7 @@
     { id: 'qianfan', name: 'Qianfan', icon: 'https://bce.bdstatic.com/img/favicon.ico', title: '百度云千帆', type: 'qianfan', url: 'https://qianfan.cloud.baidu.com/qianfandev/topic/create' },
     // [DISABLED] { id: 'alipayopen', name: 'AlipayOpen', icon: 'https://www.alipay.com/favicon.ico', title: '支付宝开放平台', type: 'alipayopen', url: 'https://open.alipay.com/portal/forum/post/add#article' },
     { id: 'modelscope', name: 'ModelScope', icon: 'https://img.alicdn.com/imgextra/i4/O1CN01fvt4it25rEZU4Gjso_!!6000000007579-2-tps-128-128.png', title: 'ModelScope 魔搭社区', type: 'modelscope', url: 'https://modelscope.cn/learn/create' },
+    { id: 'volcengine', name: 'Volcengine', icon: 'https://lf1-cdn-tos.bytegoofy.com/goofy/tech-fe/fav.png', title: '火山引擎开发者社区', type: 'volcengine', url: 'https://developer.volcengine.com/articles/draft' },
   ]
 
   // 暴露 $cose 全局对象

--- a/src/platforms/index.js
+++ b/src/platforms/index.js
@@ -25,6 +25,7 @@ import { TwitterPlatform, TwitterLoginConfig } from './twitter.js'
 import { QianfanPlatform, QianfanLoginConfig } from './qianfan.js'
 // [DISABLED] import { AlipayOpenPlatform, AlipayOpenLoginConfig } from './alipayopen.js'
 import { ModelScopePlatform, ModelScopeLoginConfig } from './modelscope.js'
+import { VolcenginePlatform, VolcengineLoginConfig } from './volcengine.js'
 
 // 合并平台配置
 const PLATFORMS = [
@@ -54,6 +55,7 @@ const PLATFORMS = [
   QianfanPlatform,
   // [DISABLED] AlipayOpenPlatform,
   ModelScopePlatform,
+  VolcenginePlatform,
 ]
 
 // 合并登录检测配置
@@ -84,6 +86,7 @@ const LOGIN_CHECK_CONFIG = {
   [QianfanPlatform.id]: QianfanLoginConfig,
   // [DISABLED] [AlipayOpenPlatform.id]: AlipayOpenLoginConfig,
   [ModelScopePlatform.id]: ModelScopeLoginConfig,
+  [VolcenginePlatform.id]: VolcengineLoginConfig,
 }
 
 // 根据 hostname 获取平台填充函数
@@ -114,6 +117,7 @@ function getPlatformFiller(hostname) {
   if (hostname.includes('qianfan.cloud.baidu.com')) return 'qianfan'
   // [DISABLED] if (hostname.includes('open.alipay.com')) return 'alipayopen'
   if (hostname.includes('modelscope.cn')) return 'modelscope'
+  if (hostname.includes('developer.volcengine.com')) return 'volcengine'
   return 'generic'
 }
 

--- a/src/platforms/volcengine.js
+++ b/src/platforms/volcengine.js
@@ -1,0 +1,25 @@
+// 火山引擎开发者社区平台配置
+const VolcenginePlatform = {
+  id: 'volcengine',
+  name: 'Volcengine',
+  icon: 'https://lf1-cdn-tos.bytegoofy.com/goofy/tech-fe/fav.png',
+  url: 'https://developer.volcengine.com/',
+  publishUrl: 'https://developer.volcengine.com/articles/draft',
+  title: '火山引擎开发者社区',
+  type: 'volcengine',
+}
+
+// 火山引擎登录检测配置
+// 使用 API 检测登录状态
+const VolcengineLoginConfig = {
+  api: 'https://developer.volcengine.com/api/fe/v1/user',
+  method: 'GET',
+  checkLogin: (response) => response?.err_no === 0 && response?.data?.user_id,
+  getUserInfo: (response) => ({
+    username: response?.data?.name,
+    avatar: response?.data?.avatar?.url,
+  }),
+}
+
+// 导出
+export { VolcenginePlatform, VolcengineLoginConfig }


### PR DESCRIPTION
## Summary / 概述
Add support for Volcengine Developer Community (火山引擎开发者社区) platform, allowing users to sync articles to https://developer.volcengine.com/articles/draft

## Related Issue / 关联 Issue
Close #109 

## Type of Change / 更改类型
- [x] New feature / 新功能 (non-breaking change that adds functionality / 添加功能的非破坏性更改)

## Changes Made / 更改内容
- Added new platform configuration file [src/platforms/volcengine.js](cci:7://file:///Users/jh/Repo/md/cose/src/platforms/volcengine.js:0:0-0:0)
- Registered Volcengine platform in [src/platforms/index.js](cci:7://file:///Users/jh/Repo/md/cose/src/platforms/index.js:0:0-0:0)
- Added platform entry in [src/inject.js](cci:7://file:///Users/jh/Repo/md/cose/src/inject.js:0:0-0:0) for frontend display
- Added `https://*.volcengine.com/*` to host permissions in [manifest.json](cci:7://file:///Users/jh/Repo/md/cose/manifest.json:0:0-0:0)
- Implemented content filling logic for ByteMD editor (CodeMirror-based) in [src/background.js](cci:7://file:///Users/jh/Repo/md/cose/src/background.js:0:0-0:0)
- Added Volcengine icons to README.md cloud platforms section

## Implementation Details / 实现细节

**Key Changes / 主要更改:**
- Platform uses API-based login detection via `https://developer.volcengine.com/api/fe/v1/user`
- Content filling targets ByteMD editor which is built on CodeMirror
- Fallback mechanism for textarea-based input if CodeMirror instance is unavailable

**Technical Notes / 技术说明:**
- Login check extracts `user_id`, `name`, and `avatar` from API response
- Editor integration uses `CodeMirror.setValue()` for direct markdown injection
- Native value setter used to bypass React controlled component restrictions

## Testing / 测试

### Testing Checklist / 测试清单
- [x] I have tested this code locally / 我已在本地测试此代码
- [x] All existing tests pass / 所有现有测试通过
- [ ] I have added tests for new functionality / 我已为新功能添加测试
- [x] I have tested on the affected platform(s) / 我已在受影响的平台上测试
- [x] I have verified the changes work in the target browser(s) / 我已验证更改在目标浏览器中有效

### Manual Testing Steps / 手动测试步骤
1. Load the extension in Chrome developer mode
2. Navigate to md.doocs.org and create/open an article
3. Select "火山引擎开发者社区" from the platform list
4. Click sync and verify content is filled correctly on the Volcengine draft page

## Screenshots/Videos / 截图/视频
N/A

## Additional Notes / 补充说明
- Volcengine Developer Community uses ByteMD as its markdown editor
- The platform icon uses the official Volcengine favicon from `https://lf1-cdn-tos.bytegoofy.com/goofy/tech-fe/fav.png`