### PR TITLE
fix: alipay open sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ _**C**reate **O**nce **S**ync **E**verywhere_
 > | S | 少数派、搜狐号、思否 |
 > | T | 腾讯云 |
 > | W | 网易号、微博文章、微信公众号 |
-> | X | X(Formerly Twitter) Articles |
+> | X | 小红书长文、X(Formerly Twitter) Articles |
 > | Z | 支付宝开放平台、知乎 |
 > | 5 | 51CTO |
 >
@@ -72,6 +72,7 @@ _**C**reate **O**nce **S**ync **E**verywhere_
 <img src="https://api.iconify.design/icon-park-solid/jinritoutiao.svg?color=%23ED1C24" alt="今日头条" width="60" height="60" />
 <img src="https://cdn.simpleicons.org/zhihu" alt="知乎" width="60" height="60" />
 <img src="https://cdn.simpleicons.org/tiktok" alt="抖音文章" width="60" height="60" />
+<img src="https://cdn.simpleicons.org/xiaohongshu" alt="小红书" width="60" height="60" />
 <img src="https://cdn.simpleicons.org/baidu" alt="百家号" width="60" height="60" />
 <img src="https://cdn.simpleicons.org/neteasecloudmusic" alt="网易号" width="60" height="60" />
 <img src="https://favicon.im/sohu.com?larger=true" alt="搜狐号" width="60" height="60" />
@@ -114,7 +115,7 @@ _**C**reate **O**nce **S**ync **E**verywhere_
   <img src="https://cdn.jsdelivr.net/npm/@lobehub/icons-static-png/dark/baiducloud-color.png" alt="百度云千帆" width="30" height="60" />
   <img src="https://cdn.jsdelivr.net/npm/@lobehub/icons-static-png/light/baiducloud-text.png" alt="百度云千帆" width="110" height="60" />
   <br />
-  <!-- <img src="https://cdn.simpleicons.org/alipay/1677FF" alt="支付宝开放平台" width="30" height="50" /> -->
+  <img src="https://cdn.simpleicons.org/alipay/1677FF" alt="支付宝开放平台" width="30" height="50" />
   <img src="https://cdn.jsdelivr.net/npm/@lobehub/icons-static-png/dark/modelscope-color.png" alt="魔搭社区" width="36" height="60" />
   <img src="https://cdn.jsdelivr.net/npm/@lobehub/icons-static-png/light/modelscope-text.png" alt="魔搭社区" width="160" height="60" />
   <img src="https://cdn.jsdelivr.net/npm/@lobehub/icons-static-png/dark/volcengine-color.png" alt="火山引擎" width="36" height="60" />


### PR DESCRIPTION
## Summary / 概述
<!-- Provide a brief description of the changes in this PR -->
<!-- 简要描述此 PR 中的更改 -->
Fix Alipay Open Platform sync issues by implementing proper content filling logic for ne-engine rich text editor and optimizing session cache timeout.

## Related Issue / 关联 Issue
<!-- Link to the related issue(s) -->
<!-- 链接到相关的 issue -->
Closes #119 

## Type of Change / 更改类型
<!-- Mark the relevant option with an "x" -->
<!-- 用 "x" 标记相关选项 -->
- [x] Bug fix / 修复 Bug (non-breaking change that fixes an issue / 修复问题的非破坏性更改)
- [ ] New feature / 新功能 (non-breaking change that adds functionality / 添加功能的非破坏性更改)
- [ ] Breaking change / 破坏性更改 (fix or feature that would cause existing functionality to not work as expected / 会导致现有功能无法正常工作的修复或功能)
- [ ] Documentation update / 文档更新
- [ ] Performance improvement / 性能优化
- [ ] Code refactoring / 代码重构
- [ ] Other / 其他 (please describe / 请描述):

## Changes Made / 更改内容
<!-- Describe the specific changes made in this PR -->
<!-- 描述此 PR 中的具体更改 -->
- Fixed content filling for Alipay Open Platform's ne-engine rich text editor
- Implemented proper title input handling for Ant Design Input components
- Adjusted session cache timeout from 7 days to 1 hour for better accuracy
- Added clipboard-based HTML content preservation
- Enhanced error handling and logging for debugging

## Implementation Details / 实现细节
<!-- Provide technical details about your implementation -->
<!-- 提供实现的技术细节 -->

**Key Changes / 主要更改:**
- Added dedicated sync handler for alipayopen in `syncToPlatform()` function
- Implemented React controlled component bypass using native value setter
- Created comprehensive event dispatching sequence for Ant Design components
- Optimized cache expiration time to match actual session validity

**Technical Notes / 技术说明:**
- Alipay Open Platform uses ne-engine editor with contenteditable divs
- Title input requires special handling due to Ant Design's internal state management
- Multiple event triggers (input, change, keydown, keyup) ensure React state synchronization
- Session timeout reduced from 7 days to 1 hour to reflect actual session duration
- ClipboardEvent with DataTransfer preserves HTML formatting better than direct DOM manipulation

## Testing / 测试
<!-- Describe the testing you performed -->
<!-- 描述您执行的测试 -->

### Testing Checklist / 测试清单
- [x] I have tested this code locally / 我已在本地测试此代码
- [ ] All existing tests pass / 所有现有测试通过
- [ ] I have added tests for new functionality / 我已为新功能添加测试
- [x] I have tested on the affected platform(s) / 我已在受影响的平台上测试
- [x] I have verified the changes work in the target browser(s) / 我已验证更改在目标浏览器中有效

### Manual Testing Steps / 手动测试步骤
1. Install extension and navigate to Alipay Open Platform publish page
2. Verify login status detection works correctly with 1-hour cache
3. Test sync workflow: confirm title is properly filled in Ant Design input
4. Verify content is correctly pasted into ne-engine editor with formatting
5. Check that HTML styling (headings, code blocks, lists) is preserved
6. Confirm error handling for expired sessions and network failures

## Screenshots/Videos / 截图/视频
<!-- If applicable, add screenshots or videos to demonstrate the changes -->
<!-- 如适用，请添加截图或视频来展示更改 -->



## Reviewer Checklist / 审阅者清单
<!-- For reviewers to verify before merging -->
<!-- 供审阅者在合并前验证 -->
- [x] Code follows the project's style guidelines / 代码遵循项目的风格指南
- [x] Changes are well-documented / 更改有良好的文档说明
- [x] No breaking changes or clearly documented if present / 无破坏性更改，或已清楚记录
- [x] Security implications have been considered / 已考虑安全影响
- [x] Performance impact has been evaluated / 已评估性能影响
- [ ] All discussions have been resolved / 所有讨论已解决


## Additional Notes / 补充说明
<!-- Any additional information that reviewers should know -->
<!-- 审阅者需要了解的其他信息 -->
- The cache timeout adjustment prevents false positive login status
- Event dispatching sequence follows Ant Design best practices
- Clipboard approach ensures consistent behavior with other platforms like WeChat
