### PR TITLE
refactor: wechat csdn juejin platforms

### DIFF
--- a/src/platforms/csdn.js
+++ b/src/platforms/csdn.js
@@ -17,45 +17,118 @@ const CSDNLoginConfig = {
   getUsernameFromCookie: true,
   usernameCookie: 'UserNick',
   usernameCookieForApi: 'UserName',
-  // 从用户页面抓取头像
-  fetchAvatarFromPage: true,
+  // 头像获取函数 - 从用户页面抓取
+  fetchAvatar: async (cookieMap) => {
+    const apiUsername = cookieMap['UserName']
+    if (!apiUsername) return null
+    try {
+      const response = await fetch(`https://blog.csdn.net/${apiUsername}`, {
+        method: 'GET',
+        credentials: 'include'
+      })
+      const html = await response.text()
+      const avatarMatch = html.match(/https:\/\/i-avatar\.csdnimg\.cn\/[^"'\s!]+/i)
+      if (avatarMatch) {
+        const originalUrl = avatarMatch[0] + '!1'
+        return `https://wsrv.nl/?url=${encodeURIComponent(originalUrl)}&w=64&h=64`
+      }
+    } catch (e) {
+      console.log('[COSE] CSDN 获取头像失败:', e.message)
+    }
+    return null
+  },
 }
 
-// CSDN 内容填充函数
-async function fillCSDNContent(content, waitFor, setInputValue) {
-  const { title, body, markdown } = content
+// CSDN 内容填充函数（在页面主世界中执行）
+// 此函数会被序列化后注入到页面中执行
+function fillCSDNContent(title, markdown, body) {
   const contentToFill = markdown || body || ''
 
-  // 填充标题
-  const titleInput = await waitFor('.article-bar__title input, input[placeholder*="标题"]')
-  setInputValue(titleInput, title)
+  // 等待元素出现的工具函数
+  function waitFor(selector, timeout = 10000) {
+    return new Promise((resolve) => {
+      const start = Date.now()
+      const check = () => {
+        const el = document.querySelector(selector)
+        if (el) resolve(el)
+        else if (Date.now() - start > timeout) resolve(null)
+        else setTimeout(check, 200)
+      }
+      check()
+    })
+  }
 
-  // 等待编辑器加载
-  await new Promise(resolve => setTimeout(resolve, 1000))
-
-  // CSDN 使用 contenteditable 的 PRE 元素
-  const editor = document.querySelector('.editor__inner[contenteditable="true"], [contenteditable="true"].markdown-highlighting')
-
-  if (editor) {
-    editor.focus()
-    // 清空现有内容
-    editor.textContent = ''
-    // 直接设置文本内容
-    editor.textContent = contentToFill
-    // 触发 input 事件让编辑器识别变化
-    editor.dispatchEvent(new Event('input', { bubbles: true }))
-    console.log('[COSE] CSDN contenteditable 填充成功')
-  } else {
-    // 降级尝试其他方式
-    const cmElement = document.querySelector('.CodeMirror')
-    if (cmElement && cmElement.CodeMirror) {
-      cmElement.CodeMirror.setValue(contentToFill)
-      console.log('[COSE] CSDN CodeMirror 填充成功')
-    } else {
-      console.log('[COSE] CSDN 未找到编辑器元素')
+  async function fill() {
+    // 填充标题
+    const titleInput = await waitFor('.article-bar__title input, input[placeholder*="标题"]')
+    if (titleInput && title) {
+      titleInput.focus()
+      titleInput.value = title
+      titleInput.dispatchEvent(new Event('input', { bubbles: true }))
     }
+
+    // 等待编辑器加载
+    await new Promise(resolve => setTimeout(resolve, 1000))
+
+    // CSDN 使用 contenteditable 的 PRE 元素
+    const editor = document.querySelector('.editor__inner[contenteditable="true"], [contenteditable="true"].markdown-highlighting')
+
+    if (editor) {
+      editor.focus()
+      // 清空现有内容
+      editor.textContent = ''
+      // 直接设置文本内容
+      editor.textContent = contentToFill
+      // 触发 input 事件让编辑器识别变化
+      editor.dispatchEvent(new Event('input', { bubbles: true }))
+      console.log('[COSE] CSDN contenteditable 填充成功')
+      return { success: true, method: 'contenteditable' }
+    } else {
+      // 降级尝试其他方式
+      const cmElement = document.querySelector('.CodeMirror')
+      if (cmElement && cmElement.CodeMirror) {
+        cmElement.CodeMirror.setValue(contentToFill)
+        console.log('[COSE] CSDN CodeMirror 填充成功')
+        return { success: true, method: 'CodeMirror' }
+      } else {
+        console.log('[COSE] CSDN 未找到编辑器元素')
+        return { success: false, error: 'Editor not found' }
+      }
+    }
+  }
+
+  return fill()
+}
+
+/**
+ * CSDN 同步处理器
+ * @param {object} tab - Chrome tab 对象
+ * @param {object} content - 内容对象 { title, body, markdown }
+ * @param {object} helpers - 帮助函数 { chrome, waitForTab, addTabToSyncGroup }
+ * @returns {Promise<{success: boolean, message?: string, tabId?: number}>}
+ */
+async function syncCSDNContent(tab, content, helpers) {
+  const { chrome } = helpers
+
+  // 等待页面加载
+  await new Promise(resolve => setTimeout(resolve, 2000))
+
+  // 在页面中执行填充脚本
+  const result = await chrome.scripting.executeScript({
+    target: { tabId: tab.id },
+    func: fillCSDNContent,
+    args: [content.title, content.markdown, content.body],
+    world: 'MAIN',
+  })
+
+  const fillResult = result?.[0]?.result
+  if (fillResult?.success) {
+    return { success: true, message: '已同步到 CSDN', tabId: tab.id }
+  } else {
+    return { success: false, message: fillResult?.error || '内容填充失败', tabId: tab.id }
   }
 }
 
 // 导出
-export { CSDNPlatform, CSDNLoginConfig, fillCSDNContent }
+export { CSDNPlatform, CSDNLoginConfig, fillCSDNContent, syncCSDNContent }
+

--- a/src/platforms/index.js
+++ b/src/platforms/index.js
@@ -1,7 +1,7 @@
 // 平台配置汇总 - 统一通过导入方式引入
-import { CSDNPlatform, CSDNLoginConfig } from './csdn.js'
-import { JuejinPlatform, JuejinLoginConfig } from './juejin.js'
-import { WechatPlatform, WechatLoginConfig } from './wechat.js'
+import { CSDNPlatform, CSDNLoginConfig, syncCSDNContent } from './csdn.js'
+import { JuejinPlatform, JuejinLoginConfig, syncJuejinContent } from './juejin.js'
+import { WechatPlatform, WechatLoginConfig, syncWechatContent } from './wechat.js'
 import { ZhihuPlatform, ZhihuLoginConfig } from './zhihu.js'
 import { ToutiaoPlatform, ToutiaoLoginConfig } from './toutiao.js'
 import { SegmentFaultPlatform, SegmentFaultLoginConfig } from './segmentfault.js'
@@ -133,5 +133,14 @@ function getPlatformFiller(hostname) {
   return 'generic'
 }
 
+// 同步处理器映射
+// 如果平台有自定义同步逻辑，在此注册处理器
+// 未注册的平台将使用 background.js 中的通用填充逻辑
+const SYNC_HANDLERS = {
+  csdn: syncCSDNContent,
+  juejin: syncJuejinContent,
+  wechat: syncWechatContent,
+}
+
 // 导出
-export { PLATFORMS, LOGIN_CHECK_CONFIG, getPlatformFiller }
+export { PLATFORMS, LOGIN_CHECK_CONFIG, SYNC_HANDLERS, getPlatformFiller }

--- a/src/platforms/juejin.js
+++ b/src/platforms/juejin.js
@@ -20,40 +20,90 @@ const JuejinLoginConfig = {
   }),
 }
 
-// 掘金内容填充函数
-async function fillJuejinContent(content, waitFor, setInputValue) {
-  const { title, body, markdown } = content
+// 掘金内容填充函数（在页面主世界中执行）
+function fillJuejinContent(title, markdown, body) {
   const contentToFill = markdown || body || ''
 
-  // 填充标题
-  const titleInput = await waitFor('input[placeholder*="标题"]')
-  if (titleInput) {
-    titleInput.focus()
-    titleInput.value = title
-    titleInput.dispatchEvent(new Event('input', { bubbles: true }))
+  // 等待元素出现的工具函数
+  function waitFor(selector, timeout = 10000) {
+    return new Promise((resolve) => {
+      const start = Date.now()
+      const check = () => {
+        const el = document.querySelector(selector)
+        if (el) resolve(el)
+        else if (Date.now() - start > timeout) resolve(null)
+        else setTimeout(check, 200)
+      }
+      check()
+    })
   }
 
-  // 等待编辑器加载
-  await new Promise(resolve => setTimeout(resolve, 1000))
-
-  // 掘金使用 ByteMD 编辑器（基于 CodeMirror）
-  const cmElement = document.querySelector('.CodeMirror')
-  if (cmElement && cmElement.CodeMirror) {
-    cmElement.CodeMirror.setValue(contentToFill)
-    console.log('[COSE] 掘金 CodeMirror 填充成功')
-  } else {
-    // 降级到 textarea
-    const textarea = document.querySelector('.bytemd-body textarea')
-    if (textarea) {
-      textarea.focus()
-      textarea.value = contentToFill
-      textarea.dispatchEvent(new Event('input', { bubbles: true }))
-      console.log('[COSE] 掘金 textarea 填充成功')
-    } else {
-      console.log('[COSE] 掘金 未找到编辑器')
+  async function fill() {
+    // 填充标题
+    const titleInput = await waitFor('input[placeholder*="标题"]')
+    if (titleInput && title) {
+      titleInput.focus()
+      titleInput.value = title
+      titleInput.dispatchEvent(new Event('input', { bubbles: true }))
     }
+
+    // 等待编辑器加载
+    await new Promise(resolve => setTimeout(resolve, 1000))
+
+    // 掘金使用 ByteMD 编辑器（基于 CodeMirror）
+    const cmElement = document.querySelector('.CodeMirror')
+    if (cmElement && cmElement.CodeMirror) {
+      cmElement.CodeMirror.setValue(contentToFill)
+      console.log('[COSE] 掘金 CodeMirror 填充成功')
+      return { success: true, method: 'CodeMirror' }
+    } else {
+      // 降级到 textarea
+      const textarea = document.querySelector('.bytemd-body textarea')
+      if (textarea) {
+        textarea.focus()
+        textarea.value = contentToFill
+        textarea.dispatchEvent(new Event('input', { bubbles: true }))
+        console.log('[COSE] 掘金 textarea 填充成功')
+        return { success: true, method: 'textarea' }
+      } else {
+        console.log('[COSE] 掘金 未找到编辑器')
+        return { success: false, error: 'Editor not found' }
+      }
+    }
+  }
+
+  return fill()
+}
+
+/**
+ * 掘金同步处理器
+ * @param {object} tab - Chrome tab 对象
+ * @param {object} content - 内容对象 { title, body, markdown }
+ * @param {object} helpers - 帮助函数 { chrome, waitForTab, addTabToSyncGroup }
+ * @returns {Promise<{success: boolean, message?: string, tabId?: number}>}
+ */
+async function syncJuejinContent(tab, content, helpers) {
+  const { chrome } = helpers
+
+  // 等待页面加载
+  await new Promise(resolve => setTimeout(resolve, 2000))
+
+  // 在页面中执行填充脚本
+  const result = await chrome.scripting.executeScript({
+    target: { tabId: tab.id },
+    func: fillJuejinContent,
+    args: [content.title, content.markdown, content.body],
+    world: 'MAIN',
+  })
+
+  const fillResult = result?.[0]?.result
+  if (fillResult?.success) {
+    return { success: true, message: '已同步到掘金', tabId: tab.id }
+  } else {
+    return { success: false, message: fillResult?.error || '内容填充失败', tabId: tab.id }
   }
 }
 
 // 导出
-export { JuejinPlatform, JuejinLoginConfig, fillJuejinContent }
+export { JuejinPlatform, JuejinLoginConfig, fillJuejinContent, syncJuejinContent }
+

--- a/src/platforms/wechat.js
+++ b/src/platforms/wechat.js
@@ -20,11 +20,271 @@ const WechatLoginConfig = {
   userInfoUrl: 'https://mp.weixin.qq.com/',
 }
 
-// 微信公众号内容填充函数
-// 注意：微信公众号使用特殊处理，此函数作为备用
-async function fillWechatContent(content, waitFor, setInputValue) {
-  console.log('[COSE] 微信公众号由特殊流程处理')
+// 微信公众号内容填充函数（在页面主世界中执行）
+function fillWechatContent(title, htmlBody) {
+  // 等待元素出现的工具函数
+  const waitForElement = (selector, timeout = 15000) => {
+    return new Promise((resolve) => {
+      const el = document.querySelector(selector)
+      if (el) return resolve(el)
+
+      const observer = new MutationObserver(() => {
+        const el = document.querySelector(selector)
+        if (el) {
+          observer.disconnect()
+          resolve(el)
+        }
+      })
+      observer.observe(document.body, { childList: true, subtree: true })
+
+      setTimeout(() => {
+        observer.disconnect()
+        resolve(document.querySelector(selector))
+      }, timeout)
+    })
+  }
+
+  async function fill() {
+    try {
+      // 等待编辑器加载完成
+      const editor = await waitForElement('.ProseMirror')
+      if (!editor) {
+        return { success: false, error: '未找到编辑器' }
+      }
+
+      // 等待标题输入框
+      const titleInput = await waitForElement('#title')
+
+      // 填充标题
+      if (titleInput && title) {
+        titleInput.focus()
+        // 使用 native setter 确保 React/Vue 等框架能检测到变化
+        const nativeSetter = Object.getOwnPropertyDescriptor(window.HTMLTextAreaElement.prototype, 'value')?.set
+        if (nativeSetter) {
+          nativeSetter.call(titleInput, title)
+        } else {
+          titleInput.value = title
+        }
+        titleInput.dispatchEvent(new Event('input', { bubbles: true }))
+        titleInput.dispatchEvent(new Event('change', { bubbles: true }))
+        console.log('[COSE] 微信标题已填充:', title)
+      }
+
+      // 稍等一下让标题生效
+      await new Promise(r => setTimeout(r, 300))
+
+      // 填充正文内容
+      if (editor && htmlBody) {
+        editor.focus()
+
+        // 清空现有占位符内容
+        if (editor.textContent.includes('从这里开始写正文')) {
+          editor.innerHTML = ''
+        }
+
+        // 使用 ClipboardEvent + DataTransfer 注入 HTML
+        const dt = new DataTransfer()
+        dt.setData('text/html', htmlBody)
+        dt.setData('text/plain', htmlBody.replace(/<[^>]*>/g, ''))
+
+        const pasteEvent = new ClipboardEvent('paste', {
+          bubbles: true,
+          cancelable: true,
+          clipboardData: dt
+        })
+
+        editor.dispatchEvent(pasteEvent)
+        console.log('[COSE] 微信内容已通过 paste 事件注入')
+
+        // 等待内容渲染
+        await new Promise(r => setTimeout(r, 500))
+
+        // 验证内容是否注入成功
+        const wordCount = editor.textContent?.length || 0
+        if (wordCount === 0) {
+          // 备用方案：直接设置 innerHTML
+          console.log('[COSE] paste 事件未生效，尝试备用方案')
+          editor.innerHTML = htmlBody
+          editor.dispatchEvent(new Event('input', { bubbles: true }))
+        }
+
+        return { 
+          success: true, 
+          wordCount: editor.textContent?.length || 0,
+          titleFilled: titleInput?.value === title
+        }
+      }
+
+      return { success: false, error: '内容为空' }
+    } catch (err) {
+      return { success: false, error: err.message }
+    }
+  }
+
+  return fill()
+}
+
+// 微信公众号保存草稿函数（在页面主世界中执行）
+function saveWechatDraft() {
+  const saveDraftBtn = Array.from(document.querySelectorAll('button'))
+    .find(b => b.textContent.includes('保存为草稿'))
+  if (saveDraftBtn) {
+    saveDraftBtn.click()
+    console.log('[COSE] 已点击保存为草稿')
+    return { success: true }
+  }
+  return { success: false, error: '未找到保存按钮' }
+}
+
+/**
+ * 微信公众号同步处理器
+ * @param {object} tab - Chrome tab 对象（初始为首页）
+ * @param {object} content - 内容对象 { title, body, markdown, wechatHtml }
+ * @param {object} helpers - 帮助函数 { chrome, waitForTab, addTabToSyncGroup, PLATFORMS }
+ * @returns {Promise<{success: boolean, message?: string, tabId?: number}>}
+ */
+async function syncWechatContent(tab, content, helpers) {
+  const { chrome, waitForTab } = helpers
+
+  // 步骤1：等待首页加载完成
+  console.log('[COSE] 微信公众号等待页面加载')
+  await waitForTab(tab.id)
+  
+  // 步骤2：使用 MutationObserver 监听获取 token
+  console.log('[COSE] 开始检测 token...')
+  const [tokenResult] = await chrome.scripting.executeScript({
+    target: { tabId: tab.id },
+    func: () => {
+      return new Promise((resolve) => {
+        // 先检查当前页面是否已有 token
+        const checkToken = () => {
+          const urlMatch = window.location.href.match(/token=(\d+)/)
+          if (urlMatch) return urlMatch[1]
+          
+          const links = document.querySelectorAll('a[href*="token"]')
+          for (const link of links) {
+            const match = link.href?.match(/token=(\d+)/)
+            if (match) return match[1]
+          }
+          
+          const scripts = document.querySelectorAll('script:not([src])')
+          for (const script of scripts) {
+            const content = script.textContent
+            const match = content.match(/token["']?\s*[:=]\s*["']?(\d+)["']?/i)
+            if (match && match[1]) return match[1]
+          }
+          return null
+        }
+
+        const existing = checkToken()
+        if (existing) return resolve(existing)
+
+        // 使用 MutationObserver 监听 DOM 变化
+        const observer = new MutationObserver(() => {
+          const token = checkToken()
+          if (token) {
+            observer.disconnect()
+            resolve(token)
+          }
+        })
+        observer.observe(document.documentElement, { childList: true, subtree: true })
+
+        // 超时保护
+        setTimeout(() => {
+          observer.disconnect()
+          resolve(checkToken())
+        }, 10000)
+      })
+    },
+    world: 'MAIN'
+  })
+  
+  const token = tokenResult?.result
+  
+  if (!token) {
+    console.error('[COSE] 无法从页面获取 token')
+    return { success: false, message: '无法获取微信公众号 token，请确保已登录', tabId: tab.id }
+  }
+  
+  // 步骤3：跳转到编辑器页面
+  const editorUrl = `https://mp.weixin.qq.com/cgi-bin/appmsg?t=media/appmsg_edit_v2&action=edit&isNew=1&type=10&token=${token}&lang=zh_CN`
+  console.log('[COSE] 获取到 token:', token, '跳转到编辑器')
+  
+  await chrome.tabs.update(tab.id, { url: editorUrl })
+  await waitForTab(tab.id)
+  
+  // 使用剪贴板 HTML（带完整样式）或降级到 body
+  const htmlContent = content.wechatHtml || content.body
+  console.log('[COSE] 微信 HTML 内容长度:', htmlContent?.length || 0)
+
+  // 步骤4：使用 MutationObserver 监听编辑器出现
+  console.log('[COSE] 正在等待编辑器...')
+  const [editorResult] = await chrome.scripting.executeScript({
+    target: { tabId: tab.id },
+    func: () => {
+      return new Promise((resolve) => {
+        const existing = document.querySelector('.ProseMirror')
+        if (existing) return resolve(true)
+
+        const observer = new MutationObserver(() => {
+          if (document.querySelector('.ProseMirror')) {
+            observer.disconnect()
+            resolve(true)
+          }
+        })
+        observer.observe(document.documentElement, { childList: true, subtree: true })
+
+        setTimeout(() => {
+          observer.disconnect()
+          resolve(!!document.querySelector('.ProseMirror'))
+        }, 15000)
+      })
+    },
+    world: 'MAIN'
+  })
+
+  if (!editorResult?.result) {
+    console.error('[COSE] 编辑器等待超时')
+    return { success: false, message: '编辑器加载超时', tabId: tab.id }
+  }
+
+  console.log('[COSE] 编辑器已就绪，开始注入内容...')
+  
+  // 步骤5：填充内容
+  let result
+  try {
+    result = await chrome.scripting.executeScript({
+      target: { tabId: tab.id },
+      func: fillWechatContent,
+      args: [content.title, htmlContent],
+      world: 'MAIN',
+    })
+  } catch (e) {
+    console.error('[COSE] executeScript 执行失败:', e)
+    return { success: false, message: '脚本执行失败: ' + e.message, tabId: tab.id }
+  }
+
+  const fillResult = result?.[0]?.result
+  console.log('[COSE] 微信填充结果:', JSON.stringify(fillResult, null, 2))
+  
+  if (!fillResult?.success) {
+    console.error('[COSE] 微信内容填充失败:', fillResult?.error)
+    return { success: false, message: fillResult?.error || '内容填充失败', tabId: tab.id }
+  }
+
+  console.log('[COSE] 微信内容填充成功，字数:', fillResult.wordCount)
+
+  // 步骤6：等待内容稳定后，点击保存为草稿按钮
+  await new Promise(resolve => setTimeout(resolve, 500))
+  await chrome.scripting.executeScript({
+    target: { tabId: tab.id },
+    func: saveWechatDraft,
+    world: 'MAIN',
+  })
+
+  return { success: true, message: '已同步并保存为草稿', tabId: tab.id }
 }
 
 // 导出
-export { WechatPlatform, WechatLoginConfig, fillWechatContent }
+export { WechatPlatform, WechatLoginConfig, fillWechatContent, syncWechatContent }
+


### PR DESCRIPTION
## Summary

Refactored the content synchronization logic for WeChat, CSDN, and Juejin platforms by moving platform-specific code from `background.js` into their respective modular files. This change introduces a centralized `SYNC_HANDLERS` registry in `index.js`, enabling a cleaner, more maintainable architecture where each platform's synchronization logic is fully encapsulated within its own module.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [x] Code refactoring
- [ ] Other (please describe):

## Changes Made

- Moved WeChat sync logic from `background.js` to `wechat.js`, including token extraction, editor detection, and draft saving
- Moved CSDN sync logic to `csdn.js` with complete content filling implementation
- Moved Juejin sync logic to `juejin.js` with CodeMirror and textarea fallback support
- Introduced `SYNC_HANDLERS` registry in `platforms/index.js` for platform-specific sync handlers
- Refactored `background.js` to use the `SYNC_HANDLERS` registry instead of inline platform-specific code
- Replaced hardcoded CSDN avatar fetching with a generic `fetchAvatar` callback pattern in login config

## Implementation Details

**Key Changes:**

- Created `syncWechatContent()`, `syncCSDNContent()`, `syncJuejinContent()` as standalone async functions in their respective platform files
- Each sync handler receives `(tab, content, helpers)` parameters for consistent interface
- The `helpers` object provides access to Chrome API and utility functions (`waitForTab`, `addTabToSyncGroup`)
- Updated exports in each platform file to include the new sync handlers
- Added `SYNC_HANDLERS` map in `index.js` that links platform IDs to their sync functions

**Technical Notes:**

- WeChat uses MutationObserver for reliable token and editor detection instead of fixed timeouts
- CSDN uses contenteditable detection with CodeMirror fallback
- Juejin uses CodeMirror API with textarea fallback for ByteMD editor
- The `fetchAvatar` callback pattern allows each platform to define custom avatar fetching logic without modifying `background.js`

## Testing

### Testing Checklist

- [x] I have tested this code locally
- [x] All existing tests pass
- [ ] I have added tests for new functionality
- [x] I have tested on the affected platform(s)
- [x] I have verified the changes work in the target browser(s)

### Manual Testing Steps

1. Install the extension and log in to WeChat Official Accounts, CSDN, and Juejin
2. Create content in the Markdown editor at `md.doocs.org`
3. Click sync button for each platform and verify content is correctly filled in the respective editor
4. For WeChat: Verify token extraction, editor navigation, and auto-save as draft works correctly

## Screenshots/Videos



## Reviewer Checklist

- [ ] Code follows the project's style guidelines
- [ ] Changes are well-documented
- [x] No breaking changes or clearly documented if present
- [ ] Security implications have been considered
- [ ] Performance impact has been evaluated
- [ ] All discussions have been resolved

## Additional Notes

This refactoring is part of an ongoing effort to modularize platform-specific code. The pattern established here (`PlatformConfig`, `LoginConfig`, `fillContent`, `syncContent`) can be applied to other platforms in future updates. Platforms without a registered sync handler will continue to use the generic sync logic in `background.js`.
