### PR TITLE
fix: hot reload filtering issue

### DIFF
--- a/apps/extension/scripts/reload-extension.mjs
+++ b/apps/extension/scripts/reload-extension.mjs
@@ -111,7 +111,7 @@ console.log('  2. chrome://extensions 页面已打开')
 console.log('  3. Developer mode 已开启')
 
 watch(distDir, { recursive: true }, (eventType, filename) => {
-    if (filename && !filename.includes('.DS_Store')) {
+    if (filename && !filename.includes('.DS_Store') && !filename.includes('_metadata')) {
         console.log(`[reload] 检测到变化: ${filename}`)
         debounceReload()
     }


### PR DESCRIPTION
## Summary / 概述

Fixed an issue where the hot reload watcher was incorrectly triggering on Chrome extension metadata files, causing unnecessary reloads during development.

## Related Issue / 关联 Issue

Closes #157 

## Type of Change / 更改类型

- [x] Bug fix / 修复 Bug (non-breaking change that fixes an issue / 修复问题的非破坏性更改)

## Changes Made / 更改内容

- Added filter condition to exclude `_metadata` files from hot reload watch in `apps/extension/scripts/reload-extension.mjs`
- The watcher now ignores both `.DS_Store` and `_metadata` files to prevent false-positive reload triggers

## Implementation Details / 实现细节

Updated the file change detection logic in the hot reload script:
- Modified line 114 to add `&& !filename.includes('_metadata')` condition
- This prevents Chrome extension metadata files (e.g., `_metadata/verified_contents.json`) from triggering unnecessary extension reloads during development

## Testing Checklist / 测试清单

- [ ] I have tested this code locally / 我已在本地测试此代码
- [ ] All existing tests pass / 所有现有测试通过
- [ ] I have added tests for new functionality / 我已为新功能添加测试
- [ ] I have tested on the affected platform(s) / 我已在受影响的平台上测试
- [ ] I have verified the changes work in the target browser(s) / 我已验证更改在目标浏览器中有效

## Manual Testing Steps / 手动测试步骤

1. Run the extension in development mode
2. Make changes to the extension code
3. Verify that the extension reloads only for actual code changes
4. Confirm that metadata file changes do not trigger reloads

## Screenshots/Videos / 截图/视频

N/A