### PR TITLE
refactor: format output structure

### DIFF
--- a/apps/extension/manifest.json
+++ b/apps/extension/manifest.json
@@ -63,7 +63,7 @@
     "default_title": "COSE"
   },
   "background": {
-    "service_worker": "src/background.js",
+    "service_worker": "bundles/background.js",
     "type": "module"
   },
   "content_scripts": [
@@ -73,7 +73,7 @@
         "https://*/*"
       ],
       "js": [
-        "src/content.js"
+        "bundles/content.js"
       ],
       "run_at": "document_idle"
     }
@@ -86,8 +86,8 @@
   "web_accessible_resources": [
     {
       "resources": [
-        "src/inject.js",
-        "src/platforms/*.js"
+        "bundles/inject.js",
+        "bundles/platforms/*.js"
       ],
       "matches": [
         "<all_urls>"

--- a/apps/extension/scripts/cli.ts
+++ b/apps/extension/scripts/cli.ts
@@ -104,7 +104,7 @@ const copyResources = async () => {
         {
             // Copy platform scripts from core package
             from: path.resolve(rootDir, '../../packages/core/src/platforms'),
-            to: path.join(rootDir, 'dist/src/platforms'),
+            to: path.join(rootDir, 'dist/bundles/platforms'),
         },
     ]
 

--- a/apps/extension/src/content.js
+++ b/apps/extension/src/content.js
@@ -104,7 +104,7 @@ console.log('[COSE Content Script] Hostname:', window.location.hostname)
 
     // 注入脚本到页面主世界
     const script = document.createElement('script')
-    script.src = chrome.runtime.getURL('src/inject.js')
+    script.src = chrome.runtime.getURL('bundles/inject.js')
     script.onload = function () {
       this.remove()
     }

--- a/apps/extension/vite.config.js
+++ b/apps/extension/vite.config.js
@@ -22,8 +22,8 @@ export default defineConfig({
                 inject: resolve(__dirname, 'src/inject.js'),
             },
             output: {
-                entryFileNames: 'src/[name].js',
-                chunkFileNames: 'src/chunks/[name].js',
+                entryFileNames: 'bundles/[name].js',
+                chunkFileNames: 'bundles/chunks/[name].js',
                 assetFileNames: 'assets/[name].[ext]',
                 format: 'es', // ES Modules，适配 Manifest V3
             },


### PR DESCRIPTION
## Summary / 概述

This PR refactors the build output directory structure by renaming `dist/src/` to `dist/bundles/` to better reflect the actual content (compiled bundles vs source code) and follow modern web development conventions.

## Related Issue / 关联 Issue

Close #161 

## Type of Change / 更改类型

- [ ] Bug fix / 修复 Bug (non-breaking change that fixes an issue / 修复问题的非破坏性更改)
- [ ] New feature / 新功能 (non-breaking change that adds functionality / 添加功能的非破坏性更改)
- [ ] Breaking change / 破坏性更改 (fix or feature that would cause existing functionality to not work as expected / 会导致现有功能无法正常工作的修复或功能)
- [ ] Documentation update / 文档更新
- [ ] Performance improvement / 性能优化
- [x] Code refactoring / 代码重构
- [ ] Other / 其他 (please describe / 请描述):

## Changes Made / 更改内容

- Updated `vite.config.js` to output bundles to `bundles/` instead of `src/`
- Modified `manifest.json` to reference scripts from `bundles/` directory
- Updated `cli.ts` build script to copy platform files to `bundles/platforms/`
- Changed `content.js` to load inject script from `bundles/inject.js`

## Implementation Details / 实现细节

**Key Changes / 主要更改:**

1. **vite.config.js** - Changed Rollup output configuration:
   - `entryFileNames`: `'src/[name].js'` → `'bundles/[name].js'`
   - `chunkFileNames`: `'src/chunks/[name].js'` → `'bundles/chunks/[name].js'`

2. **manifest.json** - Updated all script references:
   - Background service worker: `src/background.js` → `bundles/background.js`
   - Content script: `src/content.js` → `bundles/content.js`
   - Web accessible resources: `src/inject.js` → `bundles/inject.js`
   - Platform scripts: `src/platforms/*.js` → `bundles/platforms/*.js`

3. **scripts/cli.ts** - Updated copy target for platform scripts:
   - Destination: `dist/src/platforms` → `dist/bundles/platforms`

4. **src/content.js** - Updated runtime URL for inject script:
   - `chrome.runtime.getURL('src/inject.js')` → `chrome.runtime.getURL('bundles/inject.js')`

**Technical Notes / 技术说明:**

- This is a structural refactoring that improves code organization and maintainability
- The term "bundles" more accurately describes compiled/transpiled output vs "src" which implies source code
- Follows industry best practices used by Webpack, Rollup, and Parcel
- No changes to actual functionality - purely organizational improvement
- Output structure now: `dist/bundles/` for JavaScript bundles, `dist/assets/` for static assets

## Testing / 测试

### Testing Checklist / 测试清单

- [x] I have tested this code locally / 我已在本地测试此代码
- [x] All existing tests pass / 所有现有测试通过
- [ ] I have added tests for new functionality / 我已为新功能添加测试
- [x] I have tested on the affected platform(s) / 我已在受影响的平台上测试
- [x] I have verified the changes work in the target browser(s) / 我已验证更改在目标浏览器中有效

### Manual Testing Steps / 手动测试步骤

1. Run `pnpm build` to generate the new directory structure
2. Verify output directory structure shows `dist/bundles/` instead of `dist/src/`
3. Load the extension in Chrome via `chrome://extensions` (Developer mode → Load unpacked)
4. Test basic extension functionality (content scripts, background worker, inject scripts)
5. Verify all platform integrations still work correctly

## Screenshots/Videos / 截图/视频

N/A - This is an internal directory structure refactoring with no visible UI changes.

**Before:**
```
dist/
├── src/
│   ├── background.js
│   ├── content.js
│   ├── inject.js
│   └── chunks/
└── assets/
```

**After:**
```
dist/
├── bundles/
│   ├── background.js
│   ├── content.js
│   ├── inject.js
│   └── chunks/
└── assets/
```

## Reviewer Checklist / 审阅者清单

- [ ] Code follows the project's style guidelines / 代码遵循项目的风格指南
- [ ] Changes are well-documented / 更改有良好的文档说明
- [ ] No breaking changes or clearly documented if present / 无破坏性更改，或已清楚记录
- [ ] Security implications have been considered / 已考虑安全影响
- [ ] Performance impact has been evaluated / 已评估性能影响
- [ ] All discussions have been resolved / 所有讨论已解决

## Additional Notes / 补充说明

This refactoring improves code clarity and follows naming conventions that better indicate the purpose of each directory:
- `bundles/` - Compiled, bundled JavaScript ready for browser execution
- `assets/` - Static assets (icons, manifest, etc.)

The change is non-breaking for end users as they only interact with the installed extension, not the build artifacts. However, any documentation or tooling that references the old `dist/src/` path should be updated accordingly.