### PR TITLE
fix: infoq detection logic

### DIFF
--- a/packages/detection/src/detect.js
+++ b/packages/detection/src/detect.js
@@ -20,6 +20,7 @@ import { detectBilibiliUser } from './platforms/bilibili.js'
 import { detectCTO51User } from './platforms/cto51.js'
 import { detectJianshuUser } from './platforms/jianshu.js'
 import { detectSegmentFaultUser } from './platforms/segmentfault.js'
+import { detectInfoQUser } from './platforms/infoq.js'
 
 // Platform-specific detectors map
 const PLATFORM_DETECTORS = {
@@ -43,6 +44,7 @@ const PLATFORM_DETECTORS = {
     'cto51': detectCTO51User,
     'jianshu': detectJianshuUser,
     'segmentfault': detectSegmentFaultUser,
+    'infoq': detectInfoQUser,
 }
 
 export async function detectUser(platformId) {

--- a/packages/detection/src/platforms/infoq.js
+++ b/packages/detection/src/platforms/infoq.js
@@ -1,0 +1,41 @@
+import { convertAvatarToBase64 } from '../utils.js'
+
+/**
+ * InfoQ platform detection logic
+ * Strategy: POST to /public/v1/user/get_user API to get user info
+ * The old /public/v1/my/menu endpoint returns 404.
+ */
+export async function detectInfoQUser() {
+    try {
+        console.log('[COSE] InfoQ Detection: Starting')
+        const response = await fetch('https://www.infoq.cn/public/v1/user/get_user', {
+            method: 'POST',
+            credentials: 'include',
+            headers: {
+                'Content-Type': 'application/json',
+                'Accept': 'application/json',
+            },
+            body: JSON.stringify({}),
+        })
+
+        if (!response.ok) return { loggedIn: false }
+
+        const json = await response.json()
+        if (json?.code !== 0 || !json?.data?.uid) {
+            console.log('[COSE] InfoQ: Not logged in', json?.code)
+            return { loggedIn: false }
+        }
+
+        const username = json.data.nickname || ''
+        let avatar = json.data.avatar || ''
+
+        if (avatar && avatar.includes('geekbang.org')) {
+            avatar = await convertAvatarToBase64(avatar, 'https://www.infoq.cn/')
+        }
+
+        return { loggedIn: true, username, avatar }
+    } catch (e) {
+        console.error('[COSE] InfoQ Detection Error:', e)
+        return { loggedIn: false, error: e.message }
+    }
+}


### PR DESCRIPTION
## Summary

Fixed InfoQ platform user detection by switching from the deprecated `/public/v1/my/menu` endpoint (which returns 404) to the working `/public/v1/user/get_user` API endpoint.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- Created new `packages/detection/src/platforms/infoq.js` file with detection logic
- Added `detectInfoQUser` import and registration in `packages/detection/src/detect.js`
- Implemented POST request to `/public/v1/user/get_user` API endpoint

## Implementation Details

**Root Cause:**

The original InfoQ detection used the `/public/v1/my/menu` endpoint, which now returns 404 and is no longer available.

**Key Changes:**

- Use POST request to `/public/v1/user/get_user` endpoint with `credentials: 'include'` to maintain session
- Send empty JSON body `{}` as required by the API
- Parse user information from response JSON `data` object
- Extract `nickname` and `avatar` fields for user identification
- Convert avatar URLs to base64 using `convertAvatarToBase64` utility when avatar is hosted on geekbang.org to bypass CORS restrictions

**Technical Notes:**

- Checks response status code and JSON structure for proper error handling
- Validates login status by checking `code === 0` and presence of `uid`
- Properly handles missing data with optional chaining and fallback values
- Avatar conversion prevents CORS issues when displaying user images from geekbang.org domain

## Testing

### Testing Checklist

- [x] I have tested this code locally
- [x] I have tested on the affected platform(s)
- [x] I have verified the changes work in the target browser(s)

### Manual Testing Steps

1. Log in to InfoQ in the browser
2. Load the extension/application
3. Verify that InfoQ user detection works correctly
4. Confirm username and avatar are properly extracted and displayed

## Screenshots/Videos

N/A

## Additional Notes

This fix uses the current working API endpoint and follows the same pattern as other platform detectors in the codebase.