### PR TITLE
fix: elecfans detection

### DIFF
--- a/packages/detection/src/configs.js
+++ b/packages/detection/src/configs.js
@@ -295,16 +295,6 @@ export const XiaohongshuLoginConfig = {
     }),
 }
 
-// 电子发烧友
-export const ElecfansLoginConfig = {
-    api: 'https://bbs.elecfans.com/api/login/check',
-    method: 'GET',
-    checkLogin: (response) => response?.status === 1,
-    getUserInfo: (response) => ({
-        username: response?.data?.username,
-        avatar: response?.data?.avatar,
-    }),
-}
 
 // 统一的 LOGIN_CHECK_CONFIG 对象（按平台 ID 索引）
 export const LOGIN_CHECK_CONFIG = {
@@ -334,5 +324,4 @@ export const LOGIN_CHECK_CONFIG = {
     alipayopen: AlipayOpenLoginConfig,
     douyin: DouyinLoginConfig,
     xiaohongshu: XiaohongshuLoginConfig,
-    elecfans: ElecfansLoginConfig,
 }


### PR DESCRIPTION
## Summary / 概述

Fixed Elecfans (电子发烧友) login detection by migrating to the Discuz mobile API endpoint and implementing proper cookie handling to resolve authentication issues.

## Related Issue / 关联 Issue

N/A

## Type of Change / 更改类型

- [x] Bug fix / 修复 Bug (non-breaking change that fixes an issue / 修复问题的非破坏性更改)
- [ ] New feature / 新功能 (non-breaking change that adds functionality / 添加功能的非破坏性更改)
- [ ] Breaking change / 破坏性更改 (fix or feature that would cause existing functionality to not work as expected / 会导致现有功能无法正常工作的修复或功能)
- [ ] Documentation update / 文档更新
- [ ] Performance improvement / 性能优化
- [ ] Code refactoring / 代码重构
- [ ] Other / 其他 (please describe / 请描述):

## Changes Made / 更改内容

- Removed the legacy ElecfansLoginConfig from configs.js
- Completely rewrote the detectElecfansUser function in elecfans.js
- Migrated from www.elecfans.com checklogin API to bbs.elecfans.com Discuz mobile API
- Implemented manual cookie collection and attachment to work around SameSite restrictions
- Added avatar base64 conversion support
- Improved error handling and login state validation

## Implementation Details / 实现细节

**Key Changes / 主要更改:**

- **API Migration**: Changed from `/webapi/passport/checklogin` to `/api/mobile/index.php?module=profile` (Discuz standard mobile API endpoint)
- **Cookie Handling**: Used `chrome.cookies.getAll()` to collect cookies from both `.elecfans.com` domain and `bbs.elecfans.com` URL, then manually attach them via the Cookie header to bypass SameSite issues
- **Response Structure**: Updated to parse the new API response format: `{ Variables: { member_uid, space: { username, realname }, member_avatar } }`
- **Avatar Processing**: Integrated `convertAvatarToBase64()` utility to convert avatar URLs to base64 format with proper base URL handling
- **Username Fallback**: Implemented fallback logic for username: `space.username -> space.realname -> member_username`

**Technical Notes / 技术说明:**

- Removed individual cookie checks (`auth` and `auth_www`) in favor of comprehensive cookie collection
- Implemented cookie deduplication using a Set to prevent duplicate cookie entries
- Changed login validation from checking API response success to verifying `member_uid` existence
- More strict validation: returns `loggedIn: false` instead of partial success states when authentication fails
- The manual Cookie header attachment resolves issues caused by browser SameSite cookie policies

## Testing / 测试

### Testing Checklist / 测试清单

- [x] I have tested this code locally / 我已在本地测试此代码
- [x] All existing tests pass / 所有现有测试通过
- [ ] I have added tests for new functionality / 我已为新功能添加测试
- [x] I have tested on the affected platform(s) / 我已在受影响的平台上测试
- [x] I have verified the changes work in the target browser(s) / 我已验证更改在目标浏览器中有效

### Manual Testing Steps / 手动测试步骤

1. Visit bbs.elecfans.com and log in with valid credentials
2. Verify that the extension correctly detects the logged-in state
3. Confirm that username and avatar are properly extracted and displayed
4. Test logout functionality to ensure detection returns loggedIn: false

## Screenshots/Videos / 截图/视频

N/A

## Reviewer Checklist / 审阅者清单

- [ ] Code follows the project's style guidelines / 代码遵循项目的风格指南
- [ ] Changes are well-documented / 更改有良好的文档说明
- [ ] No breaking changes or clearly documented if present / 无破坏性更改，或已清楚记录
- [ ] Security implications have been considered / 已考虑安全影响
- [ ] Performance impact has been evaluated / 已评估性能影响
- [ ] All discussions have been resolved / 所有讨论已解决

## Additional Notes / 补充说明

This fix addresses authentication detection issues with the Elecfans platform. The previous implementation using the www.elecfans.com checklogin endpoint was unreliable. The new implementation uses the official Discuz mobile API which provides more stable and accurate user information.