### PR TITLE
refactor: detectByApi

### DIFF
--- a/apps/extension/src/background.js
+++ b/apps/extension/src/background.js
@@ -1,5 +1,6 @@
 // 平台配置
 import { PLATFORMS, LOGIN_CHECK_CONFIG, SYNC_HANDLERS } from '@cose/core/src/platforms/index.js'
+import { convertAvatarToBase64 } from '@cose/detection/src/utils.js'
 // [DISABLED] import { fillAlipayOpenContent } from '@cose/core/src/platforms/alipayopen.js'
 
 // 初始化动态规则：为 sinaimg 和 sspai 头像添加 CORS 头
@@ -181,8 +182,19 @@ async function handleMessage(request, sender) {
         await chrome.storage.local.set({ alipayopen_user: request.userInfo })
         console.log('[COSE] 支付宝用户信息已缓存:', request.userInfo.username)
       } else if (request.platform === 'huaweicloud' && request.userInfo) {
-        await chrome.storage.local.set({ huaweicloud_user: request.userInfo })
-        console.log('[COSE] 华为云用户信息已缓存:', request.userInfo.username)
+        const hwcInfo = { ...request.userInfo }
+        if (hwcInfo.avatar && hwcInfo.avatar.startsWith('http')) {
+          hwcInfo.avatar = await convertAvatarToBase64(hwcInfo.avatar, 'https://bbs.huaweicloud.com/')
+        }
+        await chrome.storage.local.set({ huaweicloud_user: hwcInfo })
+        console.log('[COSE] 华为云用户信息已缓存:', hwcInfo.username)
+      } else if (request.platform === 'huaweidev' && request.userInfo) {
+        const hwdInfo = { ...request.userInfo }
+        if (hwdInfo.avatar && hwdInfo.avatar.startsWith('http')) {
+          hwdInfo.avatar = await convertAvatarToBase64(hwdInfo.avatar, 'https://developer.huawei.com/')
+        }
+        await chrome.storage.local.set({ huaweidev_user: hwdInfo })
+        console.log('[COSE] 华为开发者用户信息已缓存:', hwdInfo.username)
       }
       return { success: true }
     default:

--- a/packages/detection/src/platforms/huaweicloud.js
+++ b/packages/detection/src/platforms/huaweicloud.js
@@ -21,7 +21,13 @@ export async function detectHuaweiCloudUser() {
                 const uaCookie = await chrome.cookies.get({ url: 'https://bbs.huaweicloud.com', name: 'ua' })
                 if (uaCookie && uaCookie.value) {
                     console.log('[COSE] HuaweiCloud: using cached user info:', cachedUser.username)
-                    return { loggedIn: true, username: cachedUser.username || '', avatar: cachedUser.avatar || '' }
+                    let avatar = cachedUser.avatar || ''
+                    // 如果缓存中的头像还是原始 URL（旧缓存），转换为 base64 并更新缓存
+                    if (avatar && avatar.startsWith('http')) {
+                        avatar = await convertAvatarToBase64(avatar, 'https://bbs.huaweicloud.com/')
+                        await chrome.storage.local.set({ huaweicloud_user: { ...cachedUser, avatar } })
+                    }
+                    return { loggedIn: true, username: cachedUser.username || '', avatar }
                 }
                 // cookie 已失效，清除缓存
                 console.log('[COSE] HuaweiCloud: cache exists but ua cookie gone, clearing cache')


### PR DESCRIPTION
## Summary
Refactored the detectByApi function to properly collect and send cookies in Chrome MV3 service worker environment. Also added avatar base64 conversion for HuaweiCloud and HuaweiDev platforms to resolve CORS issues.

## Changes Made
- Modified detectByApi in packages/detection/src/utils.js to use chrome.cookies.getAll() API instead of relying on credentials: 'include'
- Added explicit Cookie header construction by collecting domain and URL cookies
- Added Origin and Referer headers to API requests
- Implemented avatar base64 conversion for HuaweiCloud and HuaweiDev user info caching in background.js
- Added migration logic in huaweicloud.js to convert old cached HTTP avatar URLs to base64 format

## Technical Details
In Chrome MV3 service workers, the fetch API does not automatically include cookies with credentials: 'include'. This refactoring explicitly collects cookies using chrome.cookies.getAll() for both the domain and specific URL, deduplicates them, and constructs a Cookie header string. This ensures API requests carry necessary authentication cookies.

For HuaweiCloud platforms, avatar URLs from external domains cause CORS issues when rendered. Converting them to base64 format resolves this problem and improves offline availability.

## Type of Change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactoring (code changes that neither fix a bug nor add a feature)
- [ ] Enhancement (improvement to existing functionality)