### PR TITLE
fix: update offscreen method

### DIFF
--- a/apps/extension/manifest.json
+++ b/apps/extension/manifest.json
@@ -11,7 +11,8 @@
     "debugger",
     "clipboardRead",
     "storage",
-    "declarativeNetRequest"
+    "declarativeNetRequest",
+    "offscreen"
   ],
   "host_permissions": [
     "https://*.csdn.net/*",

--- a/apps/extension/src/offscreen.html
+++ b/apps/extension/src/offscreen.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html>
+<head><title>COSE Offscreen</title></head>
+<body>
+<script src="bundles/offscreen.js" type="module"></script>
+</body>
+</html>

--- a/apps/extension/src/offscreen.js
+++ b/apps/extension/src/offscreen.js
@@ -1,0 +1,23 @@
+// Offscreen document for making fetch requests with cookies
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  if (message.type === 'OFFSCREEN_FETCH') {
+    handleFetch(message.payload)
+      .then(result => sendResponse({ success: true, data: result }))
+      .catch(err => sendResponse({ success: false, error: err.message }))
+    return true // keep channel open for async response
+  }
+})
+
+async function handleFetch(payload) {
+  const { url, method, headers, body } = payload
+  const resp = await fetch(url, {
+    method: method || 'POST',
+    credentials: 'include',
+    headers: headers || {},
+    body: body ? JSON.stringify(body) : undefined,
+  })
+  if (!resp.ok) {
+    throw new Error(`HTTP ${resp.status}`)
+  }
+  return await resp.json()
+}


### PR DESCRIPTION
## Summary / 概述
This PR improves the Huawei Developer platform user detection by implementing an **offscreen** document solution to fetch user information with cookies when no platform tabs are open.

1. Cookie does not exist → Directly login: false, do not display avatar and nickname

2. Cookie exists but API returns failure (CSRF token expired, server rejected, etc.) → Clear cache, loggedIn: false

3. Cookie exists and API succeeds → login: true, display avatar and username

## Related Issue / 关联 Issue
N/A

## Type of Change / 更改类型
- [x] Bug fix / 修复 Bug (non-breaking change that fixes an issue / 修复问题的非破坏性更改)
- [ ] New feature / 新功能 (non-breaking change that adds functionality / 添加功能的非破坏性更改)
- [ ] Breaking change / 破坏性更改 (fix or feature that would cause existing functionality to not work as expected / 会导致现有功能无法正常工作的修复或功能)
- [ ] Documentation update / 文档更新
- [ ] Performance improvement / 性能优化
- [ ] Code refactoring / 代码重构
- [ ] Other / 其他 (please describe / 请描述):

## Changes Made / 更改内容
- Added offscreen permission to manifest.json to enable offscreen document API
- Created offscreen.html and offscreen.js to handle fetch requests with cookies in an offscreen context
- Updated huaweidev.js to use offscreen document for API calls when no platform tabs are open
- Implemented proper offscreen document lifecycle management (create, use, close)
- Enhanced user detection to verify API response success before treating as logged in

## Implementation Details / 实现细节
**Key Changes / 主要更改:**
- Added "offscreen" to Chrome extension permissions in manifest.json
- Created offscreen document infrastructure:
  - offscreen.html: Minimal HTML page for offscreen context
  - offscreen.js: Message handler for OFFSCREEN_FETCH requests with fetch implementation
- Modified huaweidev.js detection flow:
  - When developer_userdata cookie exists but no tabs are open
  - Extracts CSRF token from cookie
  - Creates offscreen document (reuses if already exists)
  - Sends fetch request through offscreen context to maintain cookie access
  - Parses response and extracts user information
  - Closes offscreen document after use
  - Only treats as logged in if API call succeeds

**Technical Notes / 技术说明:**
- Offscreen documents allow fetch requests with cookies in service worker context
- Proper error handling for offscreen document creation (handles "already exists" case)
- CSRF token extracted from developer_userdata cookie for authentication
- Avatar converted to base64 for reliable display
- Failed API calls now treated as logged out (clears stale cache)

## Testing / 测试
### Testing Checklist / 测试清单
- [x] I have tested this code locally / 我已在本地测试此代码
- [x] All existing tests pass / 所有现有测试通过
- [ ] I have added tests for new functionality / 我已为新功能添加测试
- [x] I have tested on the affected platform(s) / 我已在受影响的平台上测试
- [x] I have verified the changes work in the target browser(s) / 我已验证更改在目标浏览器中有效

### Manual Testing Steps / 手动测试步骤
1. Log in to Huawei Developer platform and verify user detection works
2. Close all Huawei Developer tabs and verify user info is still detected via offscreen fetch
3. Log out and verify detection correctly identifies logged out state

## Screenshots/Videos / 截图/视频
N/A

## Reviewer Checklist / 审阅者清单
- [ ] Code follows the project's style guidelines / 代码遵循项目的风格指南
- [ ] Changes are well-documented / 更改有良好的文档说明
- [ ] No breaking changes or clearly documented if present / 无破坏性更改，或已清楚记录
- [ ] Security implications have been considered / 已考虑安全影响
- [ ] Performance impact has been evaluated / 已评估性能影响
- [ ] All discussions have been resolved / 所有讨论已解决

## Additional Notes / 补充说明
This fix addresses the issue where user detection would fail or return incomplete information when no Huawei Developer tabs were open. The offscreen document approach allows the extension to make authenticated API calls with cookies even in the service worker context, providing a more reliable detection mechanism.