### PR TITLE
fix: message routing conflict

### DIFF
--- a/apps/extension/src/offscreen.js
+++ b/apps/extension/src/offscreen.js
@@ -1,10 +1,33 @@
 // Offscreen document for making fetch requests with cookies
+// This runs in a document context where credentials: 'include' actually works
+// (unlike the service worker where cookies are not sent/received automatically)
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   if (message.type === 'OFFSCREEN_FETCH') {
     handleFetch(message.payload)
       .then(result => sendResponse({ success: true, data: result }))
       .catch(err => sendResponse({ success: false, error: err.message }))
-    return true // keep channel open for async response
+    return true
+  }
+
+  if (message.type === 'OFFSCREEN_WARM_FETCH') {
+    handleWarmFetch(message.payload)
+      .then(result => sendResponse({ success: true, data: result }))
+      .catch(err => sendResponse({ success: false, error: err.message }))
+    return true
+  }
+
+  if (message.type === 'OFFSCREEN_API_FETCH') {
+    handleApiFetch(message.payload)
+      .then(result => sendResponse({ success: true, data: result }))
+      .catch(err => sendResponse({ success: false, error: err.message }))
+    return true
+  }
+
+  if (message.type === 'OFFSCREEN_DETECT_CTO51') {
+    handleDetectCto51()
+      .then(result => sendResponse({ success: true, data: result }))
+      .catch(err => sendResponse({ success: false, error: err.message }))
+    return true
   }
 })
 
@@ -20,4 +43,93 @@ async function handleFetch(payload) {
     throw new Error(`HTTP ${resp.status}`)
   }
   return await resp.json()
+}
+
+/**
+ * Warm-up fetch: makes a request with credentials: 'include' to trigger
+ * the browser's cookie restoration (SSO, session cookies, etc.)
+ * Returns status and response headers info, not the full body.
+ */
+async function handleWarmFetch(payload) {
+  const { url, redirect } = payload
+  try {
+    const resp = await fetch(url, {
+      method: 'GET',
+      credentials: 'include',
+      redirect: redirect || 'follow',
+    })
+    // Read a small portion to ensure the response is consumed
+    const text = await resp.text()
+    return {
+      status: resp.status,
+      url: resp.url,
+      length: text.length,
+    }
+  } catch (e) {
+    return { error: e.message }
+  }
+}
+
+/**
+ * API fetch: makes a request with credentials: 'include' and returns the response body.
+ * Used for API calls that need cookies automatically attached (since service worker
+ * fetch() strips manually-set Cookie headers in MV3).
+ */
+async function handleApiFetch(payload) {
+  const { url, method, headers, responseType, redirect } = payload
+  try {
+    const resp = await fetch(url, {
+      method: method || 'GET',
+      credentials: 'include',
+      headers: headers || {},
+      redirect: redirect || 'follow',
+    })
+    const status = resp.status
+    const finalUrl = resp.url
+    let body = null
+    if (responseType === 'json') {
+      try { body = await resp.json() } catch (e) { body = null }
+    } else {
+      body = await resp.text()
+    }
+    return { status, url: finalUrl, body }
+  } catch (e) {
+    return { error: e.message }
+  }
+}
+
+
+/**
+ * 51CTO detection: fetch home.51cto.com/space and parse with DOMParser.
+ * Same approach as 爱贝壳 extension - runs in document context (offscreen).
+ */
+async function handleDetectCto51() {
+  try {
+    const resp = await fetch('https://home.51cto.com/space')
+    const html = await resp.text()
+    const doc = new DOMParser().parseFromString(html, 'text/html')
+
+    // Avatar: <img alt="头像">
+    const avatarEl = doc.querySelector("img[alt='头像']")
+    const avatar = avatarEl ? avatarEl.getAttribute('src') : ''
+
+    // UID from avatar URL: uid=(\d+)
+    let uid = ''
+    if (avatar) {
+      const m = avatar.match(/uid=(\d+)/)
+      if (m) uid = m[1]
+    }
+
+    // Nickname: div.name > a
+    const nameEl = doc.querySelector('div.name > a')
+    const username = nameEl ? nameEl.textContent.trim() : ''
+
+    if (!username && !uid) {
+      return { loggedIn: false }
+    }
+
+    return { loggedIn: true, username, avatar, uid }
+  } catch (e) {
+    return { loggedIn: false, error: e.message }
+  }
 }

--- a/packages/detection/src/platforms/cto51.js
+++ b/packages/detection/src/platforms/cto51.js
@@ -1,67 +1,28 @@
 import { convertAvatarToBase64 } from '../utils.js'
 
 /**
- * 51CTO platform detection logic
- * Strategy:
- * 1. Fetch publish page (authenticated) — if it contains blog user ID, user is logged in
- * 2. Extract avatar from publish page
- * 3. Fetch user profile page (public) to extract username from title
+ * 51CTO platform detection logic (same approach as 爱贝壳)
+ * Fetch https://home.51cto.com/space via offscreen document,
+ * parse HTML with DOMParser to extract avatar, uid, nickname.
  */
 export async function detectCTO51User() {
     try {
-        console.log('[COSE] 51CTO Detection: Starting')
+        console.log('[COSE] 51CTO Detection: Starting (offscreen)')
 
-        let username = ''
-        let avatar = ''
-        let blogUserId = ''
-
-        // Fetch publish page (requires auth)
-        const publishResp = await fetch('https://blog.51cto.com/blogger/publish', {
-            method: 'GET',
-            credentials: 'include',
-            headers: { 'Accept': 'text/html' },
-            redirect: 'follow',
-        })
-        const publishHtml = await publishResp.text()
-
-        // Extract blog user ID from profile link
-        const blogIdMatch = publishHtml.match(/blog\.51cto\.com\/(\d{5,})/)
-        if (!blogIdMatch) {
-            console.log('[COSE] 51CTO: Not logged in (no blog user ID in publish page)')
-            return { loggedIn: false }
-        }
-        blogUserId = blogIdMatch[1]
-        console.log(`[COSE] 51CTO blog user ID: ${blogUserId}`)
-
-        // Extract avatar from publish page nav
-        const avatarMatch = publishHtml.match(/<img[^>]*data-uid=["']\d+["'][^>]*src=["'](https?:\/\/[^"']+)["']/i) ||
-            publishHtml.match(/<img[^>]*src=["'](https:\/\/s[0-9]*\.51cto\.com\/oss\/[^"']+)["'][^>]*data-uid/i)
-        if (avatarMatch && !avatarMatch[1].includes('noavatar')) {
-            avatar = avatarMatch[1]
-        }
-
-        // Fetch profile page (public) to extract username from title
-        try {
-            const profileResp = await fetch(`https://blog.51cto.com/u_${blogUserId}`, {
-                method: 'GET',
-                headers: { 'Accept': 'text/html' },
-            })
-            const profileHtml = await profileResp.text()
-            const nickMatch = profileHtml.match(/<title>([^<]+?)的博客/)
-            if (nickMatch) {
-                username = nickMatch[1].trim()
+        if (typeof globalThis.__coseDetectCto51 === 'function') {
+            const result = await globalThis.__coseDetectCto51()
+            if (result && result.loggedIn) {
+                let avatar = result.avatar || ''
+                if (avatar && avatar.startsWith('http') && avatar.includes('51cto.com')) {
+                    avatar = await convertAvatarToBase64(avatar, 'https://home.51cto.com/')
+                }
+                console.log('[COSE] 51CTO: Logged in:', result.username)
+                return { loggedIn: true, username: result.username || '', avatar }
             }
-        } catch (e) {
-            console.log('[COSE] 51CTO profile fetch failed:', e.message)
         }
 
-        console.log(`[COSE] 51CTO user info: ${username}, avatar: ${avatar ? 'found' : 'not found'}`)
-
-        if (avatar && avatar.includes('51cto.com')) {
-            avatar = await convertAvatarToBase64(avatar, 'https://blog.51cto.com/')
-        }
-
-        return { loggedIn: true, username, avatar }
+        console.log('[COSE] 51CTO: Not logged in')
+        return { loggedIn: false }
     } catch (e) {
         console.error('[COSE] 51CTO Detection Error:', e)
         return { loggedIn: false, error: e.message }


### PR DESCRIPTION
## Summary

This PR fixes a message routing conflict in the Chrome extension's background service worker. `OFFSCREEN_*` messages were being intercepted by the background `onMessage` listener before the offscreen document could handle them, causing those async handlers to never fire. The fix routes these messages directly to the offscreen document and also introduces a full offscreen-based fetch infrastructure along with a refactored 51CTO detection strategy.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [x] Code refactoring
- [ ] Other (please describe):

## Changes Made

- Fixed `OFFSCREEN_*` message routing in `background.js`: return `false` early in the `onMessage` listener so these messages pass through to the offscreen document listener instead of being consumed by the background script
- Added `ensureOffscreen()` helper to lazily create the offscreen document (guarded by `_offscreenCreated` flag)
- Added `warmUpFetch(url)` to trigger session cookie restoration via the offscreen document context
- Added `offscreenApiFetch(url, options)` for cookie-authenticated API calls from the offscreen document
- Added `tabContextFetch(siteUrl, apiUrl, options)` to inject a fetch script into an existing (or temporary) tab, bypassing SameSite=Lax cookie restrictions that block cross-site offscreen fetches
- Exposed all three fetch helpers on `globalThis` for use by detection modules
- Added `detectCto51ViaOffscreen()` in `background.js` and corresponding `handleDetectCto51()` in `offscreen.js` to detect 51CTO login via `DOMParser` in document context
- Refactored `packages/detection/src/platforms/cto51.js`: replaced the two-step publish-page + profile-page fetch approach with a single offscreen-delegated call to `__coseDetectCto51`
- Extended `offscreen.js` message listener to handle `OFFSCREEN_WARM_FETCH`, `OFFSCREEN_API_FETCH`, and `OFFSCREEN_DETECT_CTO51` message types

## Implementation Details

**Key Changes:**

- The root cause of the routing conflict: the background `onMessage` listener was registered globally and would match `OFFSCREEN_*` messages sent from `background.js` itself (via `chrome.runtime.sendMessage`). This caused `sendResponse` to be called by the background handler before the offscreen document listener could reply. Fixed by adding an early-return guard: `if (request.type?.startsWith('OFFSCREEN_')) return false`
- `tabContextFetch` finds an existing non-discarded tab matching the target domain, or creates a temporary background tab, then uses `chrome.scripting.executeScript` with `world: 'MAIN'` to make a credentialed fetch inside that page's context — necessary for sites with SameSite=Lax cookies that won't attach in offscreen document cross-site requests
- 51CTO detection now runs entirely in the offscreen document where `DOMParser` is available; it fetches `https://home.51cto.com/space`, parses the HTML, and extracts avatar URL, UID (from the avatar URL's `uid=` parameter), and nickname from `div.name > a`

**Technical Notes:**

- In MV3 service workers, `fetch()` with manually set `Cookie` headers is stripped by the browser; offscreen documents and tab-injected scripts are the only reliable ways to send credentialed requests
- The `_offscreenCreated` flag prevents redundant `chrome.offscreen.createDocument` calls; errors (e.g., document already exists) are silently swallowed and the flag is still set to `true`
- Created tabs in `tabContextFetch` are cleaned up in both the success and error paths

## Testing

### Testing Checklist

- [x] I have tested this code locally
- [x] All existing tests pass
- [ ] I have added tests for new functionality
- [x] I have tested on the affected platform(s)
- [ ] I have verified the changes work in the target browser(s)

### Manual Testing Steps

1. Install the extension from the `dev` branch and open a platform that uses offscreen detection (e.g., 51CTO)
2. Verify that the 51CTO login status is correctly detected and the username/avatar are shown
3. Open the background service worker DevTools console and confirm no `OFFSCREEN_*` routing errors appear

## Screenshots/Videos

N/A

## Reviewer Checklist

- [ ] Code follows the project's style guidelines
- [ ] Changes are well-documented
- [ ] No breaking changes or clearly documented if present
- [ ] Security implications have been considered
- [ ] Performance impact has been evaluated
- [ ] All discussions have been resolved

## Additional Notes

The `tabContextFetch` approach is intended as a fallback for platforms whose auth cookies use `SameSite=Lax` (browser default), which prevents the offscreen document from attaching them in cross-site fetches. It is currently exposed on `globalThis.__coseTabContextFetch` for optional use by future detection modules.