### PR TITLE
fix: oschina switch to Markdown editor before filling content

### DIFF
--- a/packages/detection/src/platforms/oschina.js
+++ b/packages/detection/src/platforms/oschina.js
@@ -31,6 +31,7 @@ export async function detectOSChinaUser() {
         // Best-effort: try to get username and avatar via API
         let username = ''
         let avatar = ''
+        let userId = ''
         try {
             const response = await fetch('https://apiv1.oschina.net/oschinapi/user/myDetails', {
                 method: 'GET',
@@ -44,6 +45,7 @@ export async function detectOSChinaUser() {
                 if (data?.success && data?.result?.userVo) {
                     username = data.result.userVo.name || ''
                     avatar = data.result.userVo.portraitUrl || ''
+                    userId = String(data.result.userVo.id || '')
                 }
             }
         } catch (e) {
@@ -54,7 +56,12 @@ export async function detectOSChinaUser() {
             avatar = await convertAvatarToBase64(avatar, 'https://www.oschina.net/')
         }
 
-        return { loggedIn: true, username, avatar }
+        // Store userId for sync URL construction
+        if (userId) {
+            try { await chrome.storage.local.set({ oschina_userId: userId }) } catch (e) { /* ignore */ }
+        }
+
+        return { loggedIn: true, username, avatar, userId }
     } catch (e) {
         console.error('[COSE] OSChina Detection Error:', e)
         return { loggedIn: false, error: e.message }


### PR DESCRIPTION
## Summary

This PR fixes the OSChina (开源中国) content sync flow by switching to the `ai-write` Markdown editor before filling content, instead of trying to use the legacy CKEditor rich text editor. It also migrates the OSChina user ID from ephemeral in-memory state to `chrome.storage.local`, so the ID persists correctly across service worker restarts.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Other (please describe):

## Changes Made

- **`apps/extension/src/background.js`**: In `syncToPlatform`, replaced `PLATFORM_USER_INFO['oschina']?.userId` with `await chrome.storage.local.get('oschina_userId')` to read the user ID from persistent storage. Changed the target URL suffix from `/blog/write` to `/blog/ai-write`. Completely rewrote the OSChina branch of `fillContentOnPage`: detects whether the page is currently in CKEditor mode by checking for `.editor-switch-text` containing `'切换到MD编辑器'`; if so, clicks the switch button, polls for the Ant Design confirmation dialog button (`'确定切换'`), clicks it, and waits 2 s for the Markdown editor to load. Then fills the title via native input setter + `input`/`change` event dispatch. Polls for the `<textarea>` and fills Markdown content via native textarea setter + event dispatch.
- **`packages/detection/src/platforms/oschina.js`**: After a successful login detection, persists the detected `userId` to `chrome.storage.local` as `oschina_userId`, making it available to the background service worker for URL construction.
- **`packages/core/src/platforms/oschina.js`**: Minor related updates to the OSChina platform sync configuration.

## Implementation Details

**Key Changes:**

- `syncToPlatform` (`background.js`): User ID is now read from `chrome.storage.local` on every sync call, making it resilient to MV3 service worker lifecycle restarts where in-memory state is lost.
- `fillContentOnPage` OSChina branch (`background.js`): The old implementation depended on CKEditor's global `window.CKEDITOR.instances` API, which is no longer present on the `ai-write` page. The new implementation targets the Markdown textarea directly, using native property setter to bypass React/Vue controlled input restrictions.
- Editor switch flow: The switch from rich text to Markdown is a two-step UI interaction (click switch button, confirm in modal). The code polls up to 20 times with 200 ms intervals for the confirm button to appear, accounting for Ant Design Modal animation delays.

**Technical Notes:**

- Native setters (`Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')?.set`) are used for both the title input and the Markdown textarea to trigger framework reactivity correctly.
- The `detectOSChinaUser` function in `packages/detection/src/platforms/oschina.js` now returns `userId` in its result and persists it to storage, establishing the data flow needed by the sync path.

## Testing

### Testing Checklist

- [x] I have tested this code locally
- [x] All existing tests pass
- [ ] I have added tests for new functionality
- [x] I have tested on the affected platform(s)
- [x] I have verified the changes work in the target browser(s)

### Manual Testing Steps

1. Log in to OSChina and verify that `oschina_userId` is saved to `chrome.storage.local` after detection
2. Trigger a sync to OSChina from the extension
3. Verify the extension navigates to `/blog/ai-write` (not `/blog/write`)
4. If the page opens in CKEditor mode, verify the extension automatically clicks the switch button and confirms the dialog
5. Verify the title and Markdown body are filled correctly in the editor

## Screenshots/Videos

N/A

## Reviewer Checklist

- [ ] Code follows the project's style guidelines
- [ ] Changes are well-documented
- [ ] No breaking changes or clearly documented if present
- [ ] Security implications have been considered
- [ ] Performance impact has been evaluated
- [ ] All discussions have been resolved

## Additional Notes

The polling approach (up to 20 x 200 ms = 4 s) for the confirmation dialog is intentionally conservative to accommodate slow page transitions. The 2 s post-switch wait before filling content can be adjusted if needed based on real-world performance.