### PR TITLE
fix: login detection with offscreen fallback

### DIFF
--- a/apps/extension/src/background.js
+++ b/apps/extension/src/background.js
@@ -263,6 +263,26 @@ async function detectCnblogsViaOffscreen() {
 
 globalThis.__coseDetectCnblogs = detectCnblogsViaOffscreen
 
+/**
+ * Xiaohongshu detection via offscreen document.
+ * Offscreen has document context so cookies are sent automatically.
+ */
+async function detectXiaohongshuViaOffscreen() {
+  try {
+    console.log('[COSE] Xiaohongshu: Sending OFFSCREEN_DETECT_XIAOHONGSHU message...')
+    const result = await sendOffscreenMessage({
+      type: 'OFFSCREEN_DETECT_XIAOHONGSHU',
+    })
+    console.log('[COSE] Xiaohongshu: Offscreen response:', JSON.stringify(result))
+    return result?.data || null
+  } catch (e) {
+    console.log('[COSE] Xiaohongshu offscreen detection failed:', e.message)
+    return null
+  }
+}
+
+globalThis.__coseDetectXiaohongshu = detectXiaohongshuViaOffscreen
+
 // 初始化动态规则：为 sinaimg 和 sspai 头像添加 CORS 头
 async function initDynamicRules() {
   try {

--- a/packages/detection/src/platforms/xiaohongshu.js
+++ b/packages/detection/src/platforms/xiaohongshu.js
@@ -1,64 +1,90 @@
 /**
  * Xiaohongshu (Little Red Book) platform detection logic
  * Strategy:
- * 1. Check chrome.storage.local cache (7 days TTL)
- * 2. Inject script into open creator.xiaohongshu.com tab to call API
+ * 1. Check `a1` cookie on creator.xiaohongshu.com as login indicator
+ * 2. Best-effort: fetch user info via offscreen document or open tab
+ * 3. Fall back to chrome.storage.local cache for user details
  */
 export async function detectXiaohongshuUser() {
-    const platformId = 'xiaohongshu'
     try {
-        // 先检查缓存
+        // 1. Check a1 cookie as login indicator (MV3 service worker compatible)
+        const a1Cookie = await chrome.cookies.get({ url: 'https://creator.xiaohongshu.com', name: 'a1' })
+        if (!a1Cookie || !a1Cookie.value) {
+            return { loggedIn: false }
+        }
+
+        // Logged in — now try to get user details
+
+        // 2a. Try offscreen fetch (document context, cookies sent automatically)
+        try {
+            const offscreenDetect = globalThis.__coseDetectXiaohongshu
+            if (offscreenDetect) {
+                const offResult = await offscreenDetect()
+                if (offResult && offResult.loggedIn) {
+                    // Update cache
+                    const userInfo = { ...offResult, cachedAt: Date.now() }
+                    await chrome.storage.local.set({ xiaohongshu_user: userInfo })
+                    return { loggedIn: true, username: offResult.username || '', avatar: offResult.avatar || '' }
+                }
+            }
+        } catch (e) {
+            console.log('[COSE] xiaohongshu offscreen detection failed:', e.message)
+        }
+
+        // 2b. Try open tab injection
+        try {
+            const tabs = await chrome.tabs.query({ url: 'https://creator.xiaohongshu.com/*' })
+            if (tabs.length > 0) {
+                const results = await chrome.scripting.executeScript({
+                    target: { tabId: tabs[0].id },
+                    func: async () => {
+                        try {
+                            const response = await fetch('https://creator.xiaohongshu.com/api/galaxy/user/info', {
+                                method: 'GET',
+                                credentials: 'include',
+                                headers: { 'Accept': 'application/json' }
+                            })
+                            if (!response.ok) return null
+                            const data = await response.json()
+                            if (data?.success === true && data?.code === 0 && data?.data?.userId) {
+                                return {
+                                    loggedIn: true,
+                                    username: data.data.userName || data.data.redId || '',
+                                    avatar: data.data.userAvatar || '',
+                                    userId: data.data.userId
+                                }
+                            }
+                            return null
+                        } catch (e) { return null }
+                    }
+                })
+                const result = results?.[0]?.result
+                if (result && result.loggedIn) {
+                    const userInfo = { ...result, cachedAt: Date.now() }
+                    await chrome.storage.local.set({ xiaohongshu_user: userInfo })
+                    return { loggedIn: true, username: userInfo.username || '', avatar: userInfo.avatar || '' }
+                }
+            }
+        } catch (e) {
+            console.log('[COSE] xiaohongshu tab detection failed:', e.message)
+        }
+
+        // 2c. Fall back to cache for user details
         const stored = await chrome.storage.local.get('xiaohongshu_user')
         const cachedUser = stored.xiaohongshu_user
-
-        if (cachedUser && cachedUser.loggedIn) {
+        if (cachedUser && cachedUser.username) {
             const cacheAge = Date.now() - (cachedUser.cachedAt || 0)
             const maxAge = 7 * 24 * 60 * 60 * 1000 // 7 days
             if (cacheAge < maxAge) {
-                console.log(`[COSE] xiaohongshu 从缓存读取:`, cachedUser.username)
+                console.log('[COSE] xiaohongshu 从缓存读取:', cachedUser.username)
                 return { loggedIn: true, username: cachedUser.username || '', avatar: cachedUser.avatar || '' }
-            } else {
-                await chrome.storage.local.remove('xiaohongshu_user')
             }
         }
 
-        // 缓存无效，尝试在已打开的小红书页面中检测
-        const tabs = await chrome.tabs.query({ url: 'https://creator.xiaohongshu.com/*' })
-        if (tabs.length > 0) {
-            const results = await chrome.scripting.executeScript({
-                target: { tabId: tabs[0].id },
-                func: async () => {
-                    try {
-                        const response = await fetch('https://creator.xiaohongshu.com/api/galaxy/user/info', {
-                            method: 'GET',
-                            credentials: 'include',
-                            headers: { 'Accept': 'application/json' }
-                        })
-                        if (!response.ok) return null
-                        const data = await response.json()
-                        if (data?.success === true && data?.code === 0 && data?.data?.userId) {
-                            return {
-                                loggedIn: true,
-                                username: data.data.userName || data.data.redId || '',
-                                avatar: data.data.userAvatar || '',
-                                userId: data.data.userId
-                            }
-                        }
-                        return null
-                    } catch (e) { return null }
-                }
-            })
-
-            const result = results?.[0]?.result
-            if (result && result.loggedIn) {
-                const userInfo = { ...result, cachedAt: Date.now() }
-                await chrome.storage.local.set({ xiaohongshu_user: userInfo })
-                return { loggedIn: true, username: userInfo.username || '', avatar: userInfo.avatar || '' }
-            }
-        }
-        return { loggedIn: false }
+        // Cookie exists but couldn't get user details — still logged in
+        return { loggedIn: true, username: '', avatar: '' }
     } catch (e) {
-        console.log(`[COSE] xiaohongshu 检测失败:`, e.message)
+        console.log('[COSE] xiaohongshu 检测失败:', e.message)
         return { loggedIn: false }
     }
 }


### PR DESCRIPTION
Summary / 概述  
- Refactor Xiaohongshu login detection to be MV3‑friendly by using the `a1` cookie as the primary login signal. 
- Add an offscreen document–based detection path and reuse the existing tab‑injection flow as a secondary fallback. 
- Preserve and harden the 7‑day cache for user profile details as the final fallback when live detection is unavailable. 

Related Issue / 关联 Issue  
N/A 

Type of Change / 更改类型  
- [x] Bug fix / 修复 Bug (non-breaking change that fixes an issue / 修复问题的非破坏性更改)  
- [ ] New feature / 新功能 (non-breaking change that adds functionality / 添加功能的非破坏性更改)  
- [ ] Breaking change / 破坏性更改 (fix or feature that would cause existing functionality to not work as expected / 会导致现有功能无法正常工作的修复或功能)  
- [ ] Documentation update / 文档更新  
- [ ] Performance improvement / 性能优化  
- [ ] Code refactoring / 代码重构  
- [ ] Other / 其他 (please describe / 请描述):  

Changes Made / 更改内容  
- Add `detectXiaohongshuViaOffscreen` in `background.js` to delegate Xiaohongshu detection to the offscreen document and expose it via `globalThis.__coseDetectXiaohongshu`. 
- Handle `OFFSCREEN_DETECT_XIAOHONGSHU` messages in `offscreen.js` and implement `handleDetectXiaohongshu` to call the creator user info API with cookies included.
- Rework `detectXiaohongshuUser` to use the `a1` cookie as the primary login indicator, then try offscreen detection, then tab injection, and finally fall back to the 7‑day cached user info.

Implementation Details / 实现细节  
Key Changes / 主要更改:  
- Use `chrome.cookies.get` on `https://creator.xiaohongshu.com` to quickly determine whether the user is logged in, which works reliably in a MV3 service worker. 
- Introduce an offscreen‑document fetch flow (`OFFSCREEN_DETECT_XIAOHONGSHU`) so the creator API is requested in a document context where cookies are sent automatically. 
- When live user info is available, update `chrome.storage.local.xiaohongshu_user` with `cachedAt` to support a 7‑day cache; if only the cookie exists, still report `loggedIn: true` with empty username/avatar as a graceful fallback.

Technical Notes / 技术说明:  
- All new Xiaohongshu detection logs are prefixed with `[COSE]` for traceability in both background and offscreen contexts. 
- Tab‑injection logic now focuses on retrieving structured user info when a creator tab is open, and writes the result back into the same cache schema used by the offscreen path. 

Testing / 测试  
Testing Checklist / 测试清单  
- [x] I have tested this code locally / 我已在本地测试此代码  
- [ ] All existing tests pass / 所有现有测试通过  
- [ ] I have added tests for new functionality / 我已为新功能添加测试  
- [x] I have tested on the affected platform(s) / 我已在受影响的平台上测试 (Chrome MV3 extension)
- [x] I have verified the changes work in the target browser(s) / 我已验证更改在目标浏览器中有效 (Chrome) 

Manual Testing Steps / 手动测试步骤  
1. Install the extension build from this branch in Chrome with an offscreen document configured. 
2. Log in to creator.xiaohongshu.com, open the dashboard page, and trigger the platform detection to confirm `loggedIn: true` with correct username/avatar.
3. Log out of Xiaohongshu or clear the `a1` cookie and re‑run detection to confirm it now reports `loggedIn: false` (or falls back to cache only when still valid).

Screenshots/Videos / 截图/视频  
- N/A  

Reviewer Checklist / 审阅者清单  
- [ ] Code follows the project's style guidelines / 代码遵循项目的风格指南  
- [ ] Changes are well-documented / 更改有良好的文档说明  
- [ ] No breaking changes or clearly documented if present / 无破坏性更改，或已清楚记录  
- [ ] Security implications have been considered / 已考虑安全影响  
- [ ] Performance impact has been evaluated / 已评估性能影响  
- [ ] All discussions have been resolved / 所有讨论已解决  

Additional Notes / 补充说明  
- This change ensures Xiaohongshu detection keeps working after MV3 service worker timeouts because the primary login check is cookie‑based and the heavy lifting is offloaded to the offscreen document.