### PR TITLE
fix: zhihu sync issue

### DIFF
--- a/apps/extension/src/inject.js
+++ b/apps/extension/src/inject.js
@@ -220,15 +220,28 @@
     addTask(taskData, onProgress, onComplete) {
       const { post, accounts } = taskData
       const selectedAccounts = accounts.filter(a => a.checked)
+      const seenPlatformIds = new Set()
+      const syncAccounts = []
 
-      if (selectedAccounts.length === 0) {
+      for (const account of selectedAccounts) {
+        const platformId = account.uid || account.type
+        if (!platformId) continue
+        if (seenPlatformIds.has(platformId)) {
+          console.log('[COSE] 跳过重复同步平台:', platformId)
+          continue
+        }
+        seenPlatformIds.add(platformId)
+        syncAccounts.push(account)
+      }
+
+      if (syncAccounts.length === 0) {
         if (typeof onComplete === 'function') onComplete()
         return
       }
 
       // 初始化状态
       const status = {
-        accounts: selectedAccounts.map(a => ({
+        accounts: syncAccounts.map(a => ({
           ...a,
           status: 'pending',
           msg: '等待中',
@@ -245,14 +258,14 @@
         await sendMessage('START_SYNC_BATCH', {})
 
         // 检查是否需要同步到微信公众号或百家号或网易号或 Medium 或少数派或B站专栏或微博头条或小红书（需要使用剪贴板 HTML）
-        const hasWechat = selectedAccounts.some(a => (a.uid || a.type) === 'wechat')
-        const hasBaijiahao = selectedAccounts.some(a => (a.uid || a.type) === 'baijiahao')
-        const hasWangyihao = selectedAccounts.some(a => (a.uid || a.type) === 'wangyihao')
-        const hasMedium = selectedAccounts.some(a => (a.uid || a.type) === 'medium')
-        const hasSspai = selectedAccounts.some(a => (a.uid || a.type) === 'sspai')
-        const hasBilibili = selectedAccounts.some(a => (a.uid || a.type) === 'bilibili')
-        const hasWeibo = selectedAccounts.some(a => (a.uid || a.type) === 'weibo')
-        const hasXiaohongshu = selectedAccounts.some(a => (a.uid || a.type) === 'xiaohongshu')
+        const hasWechat = syncAccounts.some(a => (a.uid || a.type) === 'wechat')
+        const hasBaijiahao = syncAccounts.some(a => (a.uid || a.type) === 'baijiahao')
+        const hasWangyihao = syncAccounts.some(a => (a.uid || a.type) === 'wangyihao')
+        const hasMedium = syncAccounts.some(a => (a.uid || a.type) === 'medium')
+        const hasSspai = syncAccounts.some(a => (a.uid || a.type) === 'sspai')
+        const hasBilibili = syncAccounts.some(a => (a.uid || a.type) === 'bilibili')
+        const hasWeibo = syncAccounts.some(a => (a.uid || a.type) === 'weibo')
+        const hasXiaohongshu = syncAccounts.some(a => (a.uid || a.type) === 'xiaohongshu')
         let clipboardHtmlContent = null
         if (hasWechat || hasBaijiahao || hasWangyihao || hasMedium || hasSspai || hasBilibili || hasWeibo || hasXiaohongshu) {
           // 先点击复制按钮，将带样式的内容复制到剪贴板
@@ -282,8 +295,8 @@
           }
         }
 
-        for (let i = 0; i < selectedAccounts.length; i++) {
-          const account = selectedAccounts[i]
+        for (let i = 0; i < syncAccounts.length; i++) {
+          const account = syncAccounts[i]
           status.accounts[i].status = 'uploading'
           status.accounts[i].msg = '同步中...'
           if (typeof onProgress === 'function') onProgress({ ...status })

--- a/packages/core/src/platforms/zhihu.js
+++ b/packages/core/src/platforms/zhihu.js
@@ -55,7 +55,10 @@ function fillZhihuContent(title, markdown) {
   }
 
   async function fillContent() {
-    // 第一步：填充标题
+    // 第一步：等待知乎编辑器完全加载（避免"草稿加载中"提示）
+    await new Promise(resolve => setTimeout(resolve, 2000))
+    
+    // 第二步：填充标题
     async function fillTitle() {
       const titleInput = await window.waitFor('textarea[placeholder*="标题"]')
       if (titleInput && title) {
@@ -74,8 +77,14 @@ function fillZhihuContent(title, markdown) {
         console.log('[COSE] 知乎标题填充成功')
       }
     }
+    
+    // 先填充标题
+    await fillTitle()
+    
+    // 再等待一下确保标题已保存
+    await new Promise(resolve => setTimeout(resolve, 500))
 
-    // 第二步：找到并激活知乎编辑器
+    // 第三步：找到并激活知乎编辑器
     const editorSelectors = [
       '.public-DraftEditor-content',
       '[contenteditable="true"]',
@@ -185,9 +194,6 @@ function fillZhihuContent(title, markdown) {
     // 等待内容渲染
     await new Promise(resolve => setTimeout(resolve, 300))
 
-    // 填充标题
-    await fillTitle()
-
     return { success: true, method: 'paste-markdown' }
   }
 
@@ -207,6 +213,16 @@ async function syncZhihuContent(tab, content, helpers) {
 
   // 等待页面加载完成（waitForTab 使用 chrome.tabs.onUpdated 监听）
   await waitForTab(tab.id)
+
+  // 激活知乎标签页（避免后台标签页限制导致填充失败）
+  try {
+    await chrome.tabs.update(tab.id, { active: true })
+    console.log('[COSE] 已激活知乎标签页')
+    // 等待标签页激活完成
+    await new Promise(resolve => setTimeout(resolve, 500))
+  } catch (err) {
+    console.log('[COSE] 激活标签页失败:', err.message || err)
+  }
 
   // 先注入公共工具函数（waitFor 使用 MutationObserver）
   await injectUtils(globalThis.chrome, tab.id)


### PR DESCRIPTION
## Summary

Fixes intermittent content fill failures when syncing to Zhihu, caused by the editor's async draft loading and browser throttling on background tabs. Also introduces platform-level deduplication to prevent the same platform from being synced multiple times in a single batch.

## Related Issue

Closes #227

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Other (please describe):

## Changes Made

**`packages/core/src/platforms/zhihu.js`**
- Added a 2-second initial delay before filling content to wait for the Zhihu draft editor to fully initialize, preventing the "Draft Loading" popup from interrupting the fill sequence.
- Reordered fill steps: title is now filled first, followed by a 500ms stabilization delay, before the body editor is activated and content is pasted.
- Added `chrome.tabs.update({ active: true })` with a 500ms wait after tab load to activate the Zhihu tab before injection, avoiding browser throttling on background tabs.

**`apps/extension/src/inject.js`**
- Introduced `seenPlatformIds` (a `Set`) and `syncAccounts` (a filtered array) to deduplicate selected accounts by `uid || type` before the sync batch begins.
- All downstream references (`hasWechat`, `hasBaijiahao`, `hasWangyihao`, etc., and the main sync loop) now operate on the deduplicated `syncAccounts` instead of the raw `selectedAccounts`.
- Duplicate platforms are skipped with a `[COSE] 跳过重复同步平台:` console log.

## Implementation Details

**Key Changes:**
- `fillContent()` in `zhihu.js`: initial 2s wait -> fill title -> 500ms wait -> activate editor -> paste body (previously: activate editor -> paste body -> fill title at the end, with no initial wait).
- `syncZhihuContent()` in `zhihu.js`: calls `chrome.tabs.update(tab.id, { active: true })` after `waitForTab()` to bring the tab to the foreground before injecting content scripts.
- `addTask()` in `inject.js`: deduplication loop runs over `selectedAccounts` and produces `syncAccounts`, which replaces `selectedAccounts` for all subsequent logic.

**Technical Notes:**
- The 2s delay is a pragmatic guard for Zhihu's async draft restore; a more robust solution (polling for editor readiness) can be considered as a follow-up.
- Platform ID is derived as `account.uid || account.type`, consistent with the existing `has*` checks in the same function.

## Testing

### Testing Checklist

- [x] I have tested this code locally
- [x] I have tested on the affected platform (Zhihu)
- [x] I have verified the changes work in the target browser(s)
- [ ] All existing tests pass
- [ ] I have added tests for new functionality

### Manual Testing Steps

1. Open `md.doocs.org`, write an article, and publish to Zhihu only.
2. Trigger sync without switching to the newly opened Zhihu tab - verify no "Draft Loading" popup interrupts the fill.
3. Select the same Zhihu account twice (if UI allows) or simulate duplicate entries - verify only one sync request is sent.
4. Confirm title and body are both filled correctly and Markdown conversion is triggered.

## Screenshots/Videos

<!-- If applicable, add screenshots or videos to demonstrate the changes -->