### PR TITLE
fix: douban detection error

### DIFF
--- a/packages/detection/src/platforms/douban.js
+++ b/packages/detection/src/platforms/douban.js
@@ -67,6 +67,7 @@ export async function detectDoubanUser() {
         let username = ''
         let avatar = ''
         let uid = ''
+        let loginConfirmed = false
 
         // 2. Parse /mine/ HTML to get user info
         try {
@@ -83,7 +84,17 @@ export async function detectDoubanUser() {
             })
 
             if (response.ok) {
+                const finalUrl = response.url || ''
                 const html = await response.text()
+                const redirectedToLogin = /\/accounts\/login/i.test(finalUrl)
+                    || /name=["']form_email["']/i.test(html)
+                    || /登录豆瓣|扫码登录/i.test(html)
+                const hasUserSignals = /的账号</.test(html)
+                    || /https?:\/\/www\.douban\.com\/people\/([^/"?#]+)\/?/.test(html)
+                    || /\/people\/([^/"?#]+)\/?/.test(html)
+                    || /doubanio\.com\/icon\//i.test(html)
+
+                loginConfirmed = !redirectedToLogin && hasUserSignals
 
                 if (!username) {
                     const accountMatch = html.match(/>([^<\n]+)的账号</)
@@ -125,11 +136,16 @@ export async function detectDoubanUser() {
         }
 
         // 3. Fallback: derive uid from dbcl2 cookie as username placeholder
-        if (!username && !uid && dbcl2Cookie.value) {
+        if (loginConfirmed && !username && !uid && dbcl2Cookie.value) {
             const uidFromCookie = dbcl2Cookie.value.match(/"?([^:"]+):/)
             if (uidFromCookie?.[1]) {
                 uid = uidFromCookie[1]
             }
+        }
+
+        if (!loginConfirmed) {
+            console.log('[COSE] douban 仅有 cookie，未确认登录态，按未登录处理')
+            return { loggedIn: false }
         }
 
         if (!username && uid) {


### PR DESCRIPTION
## Summary

Fix a false-positive login detection bug in the Douban platform detector. Previously, the presence of the `dbcl2` cookie alone was sufficient to trigger a "logged in" result, even when the user had actually been redirected to the login page. This PR introduces an explicit login confirmation step before treating the user as authenticated.


## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code refactoring
- [ ] Other (please describe):

## Changes Made

- Added a `loginConfirmed` boolean flag (initialized to `false`) in `detectDoubanUser()`
- After fetching `/mine/`, capture the final response URL and check whether the request was redirected to the login page (via URL pattern, form field, or page text patterns like "登录豆瓣" / "扫码登录")
- Check for user-presence signals in the HTML (profile URL patterns, doubanio icon URL, account reference text)
- Set `loginConfirmed = !redirectedToLogin && hasUserSignals` to confirm actual login state
- Guard the `dbcl2` cookie UID fallback with `loginConfirmed` to prevent false positives
- Early-return `{ loggedIn: false }` with a console warning if `loginConfirmed` is false after all checks

## Implementation Details

**Key Changes:**
- `packages/detection/src/platforms/douban.js`: added redirect detection logic and `loginConfirmed` guard in `detectDoubanUser()`

**Technical Notes:**
- `redirectedToLogin` checks the final URL for `/accounts/login/`, form fields (`name=["']form_email`), and login page text
- `hasUserSignals` checks for profile URL patterns (`/people/...`), doubanio icon URLs, and account-related Chinese text
- Only when both conditions pass (`!redirectedToLogin && hasUserSignals`) is the user considered logged in

## Testing

Manually tested on the Douban platform under the following scenarios:
- Logged-in user: correctly detected as logged in
- Not logged in but `dbcl2` cookie present: correctly detected as not logged in (previously a false positive)
- Fully logged-out (no cookie): correctly detected as not logged in

### Testing Checklist

- [x] I have tested this code locally
- [x] All existing tests pass
- [ ] I have added tests for new functionality
- [x] I have tested on the affected platform (Douban)