### PR TITLE
feat: add popup page for extension installation guide

### DIFF
--- a/apps/extension/manifest.json
+++ b/apps/extension/manifest.json
@@ -63,7 +63,8 @@
       "48": "icons/cose_48.png",
       "128": "icons/cose_128.png"
     },
-    "default_title": "COSE"
+    "default_title": "COSE",
+    "default_popup": "popup.html"
   },
   "background": {
     "service_worker": "bundles/background.js",

--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cose-extension",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "description": "Create Once, Sync Everywhere. 一键将文章同步到多个平台",
   "type": "module",
   "scripts": {

--- a/apps/extension/src/background.js
+++ b/apps/extension/src/background.js
@@ -350,11 +350,6 @@ chrome.runtime.onStartup.addListener(() => {
   initDynamicRules()
 })
 
-// 点击扩展图标时打开 md.doocs.org
-chrome.action.onClicked.addListener(() => {
-  chrome.tabs.create({ url: 'https://md.doocs.org' })
-})
-
 // 当前同步任务的 Tab Group ID
 let currentSyncGroupId = null
 // 存储平台用户信息
@@ -1088,8 +1083,11 @@ async function syncToPlatform(platformId, content) {
             html = html.replace(/^> (.+)$/gm, '<blockquote>$1</blockquote>')
 
             // 处理水平分割线
-            html = html.replace(/^---$/gm, '<hr />')
-            html = html.replace(/^\*\*\*$/gm, '<hr />')
+            // 注意: X Articles 忽略 <hr> 标签，需要通过 Insert > Divider 菜单插入
+            // 自动同步无法使用菜单，这里保留 hr 但用户可能需要手动调整
+            // 或者可以考虑用视觉分隔符如 --- 文本替代
+            html = html.replace(/^---$/gm, '<p>---</p>')
+            html = html.replace(/^\*\*\*$/gm, '<p>***</p>')
 
             // 处理图片
             html = html.replace(/!\[([^\]]*)\]\(([^)]+)\)/g, '<img src="$2" alt="$1" style="max-width: 100%;" />')
@@ -1104,7 +1102,8 @@ async function syncToPlatform(platformId, content) {
 
             // ========== 第三阶段：恢复保护的内容 ==========
 
-            // 恢复代码块（使用样式化的 pre/code）
+            // 恢复代码块 - X Articles 不支持 <pre><code>，转换为 blockquote
+            // 参考 x-article-publisher skill 的实现
             codeBlocks.forEach((block, index) => {
               const escapedCode = block.code
                 .replace(/&/g, '&amp;')
@@ -1113,19 +1112,25 @@ async function syncToPlatform(platformId, content) {
                 .replace(/"/g, '&quot;')
                 .replace(/'/g, '&#039;')
 
-              const langLabel = block.lang ? `<div style="background: #e1e4e8; padding: 4px 12px; font-size: 12px; color: #586069; border-radius: 6px 6px 0 0;">${block.lang}</div>` : ''
-              const codeHtml = `<div style="margin: 16px 0;">${langLabel}<pre style="background: #f6f8fa; padding: 16px; border-radius: ${block.lang ? '0 0 6px 6px' : '6px'}; overflow-x: auto; font-family: 'SF Mono', Consolas, 'Liberation Mono', Menlo, monospace; font-size: 14px; line-height: 1.45; margin: 0; white-space: pre-wrap; word-wrap: break-word;"><code>${escapedCode}</code></pre></div>`
+              // 将代码行用 <br> 连接，包装在 blockquote 中
+              // X Articles 原生支持 blockquote，这是最可靠的代码块显示方式
+              const lines = escapedCode.split('\n').filter(line => line.trim())
+              const formattedCode = lines.join('<br>')
+              const langPrefix = block.lang ? `<strong>${block.lang}</strong><br>` : ''
+              const codeHtml = `<blockquote>${langPrefix}${formattedCode}</blockquote>`
 
               html = html.replace(`__CODE_BLOCK_${index}__`, codeHtml)
             })
 
-            // 恢复行内代码
+            // 恢复行内代码 - X Articles 对 inline style 支持有限
+            // 使用简单的 <code> 标签，依赖平台默认样式
             inlineCodes.forEach((code, index) => {
               const escapedCode = code
                 .replace(/&/g, '&amp;')
                 .replace(/</g, '&lt;')
                 .replace(/>/g, '&gt;')
-              const codeHtml = `<code style="background: #f6f8fa; padding: 2px 6px; border-radius: 3px; font-family: 'SF Mono', Consolas, monospace; font-size: 0.9em;">${escapedCode}</code>`
+              // 简化为纯 code 标签，X Articles 会应用默认样式
+              const codeHtml = `<code>${escapedCode}</code>`
 
               html = html.replace(`__INLINE_CODE_${index}__`, codeHtml)
             })

--- a/apps/extension/src/popup.html
+++ b/apps/extension/src/popup.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <style>
+    * {
+      margin: 0;
+      padding: 0;
+      box-sizing: border-box;
+    }
+    body {
+      width: 320px;
+      padding: 20px;
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+      background: #fff;
+      color: #333;
+    }
+    .container {
+      text-align: center;
+    }
+    h1 {
+      font-size: 18px;
+      font-weight: 600;
+      margin-bottom: 12px;
+    }
+    p {
+      font-size: 13px;
+      line-height: 1.6;
+      color: #333;
+      margin-bottom: 16px;
+    }
+    p a {
+      color: #FE5200;
+      text-decoration: none;
+    }
+    p a:hover {
+      text-decoration: underline;
+    }
+    .btn {
+      display: inline-block;
+      padding: 10px 20px;
+      background: #FE5200;
+      color: #fff;
+      text-decoration: none;
+      border-radius: 8px;
+      font-size: 14px;
+      font-weight: 500;
+      transition: background 0.2s;
+      border: 1px solid #e64a00;
+      cursor: pointer;
+    }
+    .btn:hover {
+      background: #e64a00;
+    }
+    .divider {
+      margin: 16px 0;
+      border-top: 1px solid #e5e5e5;
+    }
+    .hint {
+      font-size: 12px;
+      color: #666;
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>COSE - 多平台文章同步</h1>
+    <p>插件安装完成！</p>
+    <p>打开<a href="https://github.com/doocs/md" target="_blank">自托管的编辑器</a>即可自动检测到，无需多余配置。</p>
+    <div class="divider"></div>
+    <p class="hint">没有自托管编辑器？</p>
+    <a href="https://md.doocs.org" target="_blank" class="btn" id="openOfficial">也可使用官网编辑器</a>
+  </div>
+  <script src="bundles/popup.js" type="module"></script>
+</body>
+</html>

--- a/apps/extension/src/popup.js
+++ b/apps/extension/src/popup.js
@@ -1,0 +1,6 @@
+// Popup script for COSE extension
+document.getElementById('openOfficial').addEventListener('click', (e) => {
+  e.preventDefault()
+  chrome.tabs.create({ url: 'https://md.doocs.org' })
+  window.close()
+})

--- a/apps/extension/vite.config.js
+++ b/apps/extension/vite.config.js
@@ -21,6 +21,7 @@ export default defineConfig({
                 content: resolve(__dirname, 'src/content.js'),
                 inject: resolve(__dirname, 'src/inject.js'),
                 offscreen: resolve(__dirname, 'src/offscreen.js'),
+                popup: resolve(__dirname, 'src/popup.js'),
             },
             output: {
                 entryFileNames: 'bundles/[name].js',
@@ -40,6 +41,10 @@ export default defineConfig({
                 },
                 {
                     src: 'src/offscreen.html',
+                    dest: '.',
+                },
+                {
+                    src: 'src/popup.html',
                     dest: '.',
                 },
                 {


### PR DESCRIPTION
## Summary / 概述
<!-- Provide a brief description of the changes in this PR -->
<!-- 简要描述此 PR 中的更改 -->
Introduces a popup page for the COSE browser extension that serves as an installation guide. When users click the extension icon, they are now directed to a dedicated popup UI instead of directly opening a new tab. The popup prompts users to open the hosted editor (md.doocs.org) and handles the navigation via a button click. Additionally, this PR refactors the X Articles code block rendering logic to use `<blockquote>` instead of styled `<pre>/<code>` elements, improving compatibility with the X Articles platform.

## Related Issue / 关联 Issue
<!-- Link to the related issue(s) -->
<!-- 链接到相关的 issue -->
Re doocs/md/issues/1387

## Type of Change / 更改类型
<!-- Mark the relevant option with an "x" -->
<!-- 用 "x" 标记相关选项 -->
- [ ] Bug fix / 修复 Bug (non-breaking change that fixes an issue / 修复问题的非破坏性更改)
- [x] New feature / 新功能 (non-breaking change that adds functionality / 添加功能的非破坏性更改)
- [ ] Breaking change / 破坏性更改 (fix or feature that would cause existing functionality to not work as expected / 会导致现有功能无法正常工作的修复或功能)
- [ ] Documentation update / 文档更新
- [ ] Performance improvement / 性能优化
- [x] Code refactoring / 代码重构
- [ ] Other / 其他 (please describe / 请描述):

## Changes Made / 更改内容
<!-- Describe the specific changes made in this PR -->
<!-- 描述此 PR 中的具体更改 -->
- Added `apps/extension/src/popup.html`: new popup page with installation guide UI, linking users to md.doocs.org
- Added `apps/extension/src/popup.js`: click handler for the "Open Official Editor" button, opens md.doocs.org in a new tab and closes the popup
- Updated `apps/extension/manifest.json`: registered `popup.html` as `default_popup`, removed direct tab-open behavior on icon click
- Updated `apps/extension/src/background.js`: removed `chrome.action.onClicked` listener (replaced by popup); refactored X Articles code block rendering to use `<blockquote>` instead of styled `<pre><code>` elements; updated horizontal rule handling; improved inline code rendering to use plain `<code>` tags
- Updated `apps/extension/vite.config.js`: added `popup` entry point (`src/popup.js`) and corresponding HTML output (`src/popup.html`) to the build config
- Bumped version in `apps/extension/package.json` from `1.3.3` to `1.3.4`

## Implementation Details / 实现细节
<!-- Provide technical details about your implementation -->
<!-- 提供实现的技术细节 -->
**Key Changes / 主要更改:**
- The extension popup (`popup.html` + `popup.js`) replaces the previous `chrome.action.onClicked` listener. Clicking the toolbar icon now shows a small guide UI rather than immediately navigating to a URL.
- X Articles code block rendering now wraps formatted code lines in `<blockquote>` tags with a language prefix (`<strong>{lang}</strong>`), which is the natively supported display format on X Articles, instead of custom-styled `<pre><code>` HTML.
- Inline code in X Articles context is simplified to plain `<code>` tags, matching X Articles' default rendering style.
- Horizontal rule (`---`) handling is updated: X Articles does not natively support `<hr>`; the new logic converts them to `<p>----</p>` as a text-based substitute.

**Technical Notes / 技术说明:**
- The popup build entry is added to `vite.config.js` under the `rollupOptions.input` map and a corresponding output entry is added so the bundler emits `popup.html` correctly.
- `background.js` no longer needs a `chrome.action.onClicked` listener since `default_popup` in the manifest takes precedence and handles the click event.

## Testing / 测试
<!-- Describe the testing you performed -->
<!-- 描述您执行的测试 -->`
### Testing Checklist / 测试清单
- [x] I have tested this code locally / 我已在本地测试此代码
- [x] All existing tests pass / 所有现有测试通过
- [ ] I have added tests for new functionality / 我已为新功能添加测试
- [x] I have tested on the affected platform(s) / 我已在受影响的平台上测试
- [x] I have verified the changes work in the target browser(s) / 我已验证更改在目标浏览器中有效

### Manual Testing Steps / 手动测试步骤
1. Build the extension (`pnpm build` inside `apps/extension`) and load the unpacked extension in Chrome.
2. Click the COSE toolbar icon — the popup page should appear with the installation guide and an "Open Official Editor" button.
3. Click the button — md.doocs.org should open in a new tab and the popup should close.
4. Open an article in the editor, sync to X Articles, and verify that code blocks render correctly using `<blockquote>` format and that horizontal rules appear as `----`.

## Screenshots/Videos / 截图/视频
<!-- If applicable, add screenshots or videos to demonstrate the changes -->
<!-- 如适用，请添加截图或视频来展示更改 -->

## Reviewer Checklist / 审阅者清单
<!-- For reviewers to verify before merging -->
<!-- 供审阅者在合并前验证 -->
- [ ] Code follows the project's style guidelines / 代码遵循项目的风格指南
- [ ] Changes are well-documented / 更改有良好的文档说明
- [ ] No breaking changes or clearly documented if present / 无破坏性更改，或已清楚记录
- [ ] Security implications have been considered / 已考虑安全影响
- [ ] Performance impact has been evaluated / 已评估性能影响
- [ ] All discussions have been resolved / 所有讨论已解决

## Additional Notes / 补充说明
<!-- Any additional information that reviewers should know -->
<!-- 审阅者需要了解的其他信息 -->
- This version bump (`1.3.3` → `1.3.4`) reflects the new popup feature and the rendering improvements.
- The `default_popup` manifest field takes exclusive control of the toolbar icon click; any `chrome.action.onClicked` listener in `background.js` would be silently ignored, so it has been removed to keep the codebase clean.