### PR TITLE
fix(wechat): wait for the body editor before pasting

### DIFF
--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cose-extension",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "description": "Create Once, Sync Everywhere. 一键将文章同步到多个平台",
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "dev": "pnpm -C apps/extension dev",
     "dev:chrome": "pnpm -C apps/extension dev:chrome",
     "dev:watch": "pnpm -C apps/extension dev:watch",
-    "lint": "pnpm -r lint"
+    "lint": "pnpm -r lint",
+    "test": "node --test"
   },
   "devDependencies": {
     "typescript": "^5.0.0"

--- a/packages/core/src/platforms/wechat.js
+++ b/packages/core/src/platforms/wechat.js
@@ -57,13 +57,48 @@ async function fillWechatContent(title, htmlBody) {
    * 另外，正文编辑器有时会比标题编辑器晚挂载，这时也要继续等待，不能把唯一节点误判成正文。
    */
   function pickWechatBodyProseMirror() {
+    // 内联辅助函数，确保 chrome.scripting.executeScript 注入时可用
+    function getEditorArea(editor) {
+      return (editor?.clientHeight || 0) * (editor?.clientWidth || 0)
+    }
+    function isWechatTitleEditor(editor, titleEditor) {
+      return Boolean(editor)
+        && (editor === titleEditor || Boolean(editor.closest?.('.title-editor__input')))
+    }
+    function pickCandidate(nodes, { titleInput, titleEditor } = {}) {
+      const bodyCandidates = nodes.filter(editor => !isWechatTitleEditor(editor, titleEditor))
+      if (bodyCandidates.length === 0)
+        return null
+      if (bodyCandidates.length === 1)
+        return bodyCandidates[0]
+
+      const byPlaceholder = bodyCandidates.find(editor =>
+        (editor.textContent || '').includes('从这里开始写正文'),
+      )
+      if (byPlaceholder)
+        return byPlaceholder
+
+      if (titleInput) {
+        const band = titleInput.getBoundingClientRect()
+        const belowTitle = bodyCandidates.filter((editor) => {
+          const rect = editor.getBoundingClientRect()
+          return rect.top >= band.bottom - 8
+        })
+        if (belowTitle.length > 0) {
+          return belowTitle.sort((a, b) => getEditorArea(b) - getEditorArea(a))[0]
+        }
+      }
+
+      return bodyCandidates.sort((a, b) => getEditorArea(b) - getEditorArea(a))[0]
+    }
+
     const nodes = [...document.querySelectorAll('.ProseMirror')]
     if (nodes.length === 0)
       return null
 
     const titleInput = document.querySelector('#title')
     const titleEditor = document.querySelector('.title-editor__input .ProseMirror')
-    return pickWechatBodyProseMirrorCandidate(nodes, { titleInput, titleEditor })
+    return pickCandidate(nodes, { titleInput, titleEditor })
   }
 
   async function waitForBodyEditor(timeout = 15000) {

--- a/packages/core/src/platforms/wechat.js
+++ b/packages/core/src/platforms/wechat.js
@@ -12,43 +12,58 @@ const WechatPlatform = {
   type: 'wechat',
 }
 
+function getEditorArea(editor) {
+  return (editor?.clientHeight || 0) * (editor?.clientWidth || 0)
+}
+
+function isWechatTitleEditor(editor, titleEditor) {
+  return Boolean(editor)
+    && (editor === titleEditor || Boolean(editor.closest?.('.title-editor__input')))
+}
+
+function pickWechatBodyProseMirrorCandidate(nodes, { titleInput, titleEditor } = {}) {
+  const bodyCandidates = nodes.filter(editor => !isWechatTitleEditor(editor, titleEditor))
+  if (bodyCandidates.length === 0)
+    return null
+  if (bodyCandidates.length === 1)
+    return bodyCandidates[0]
+
+  const byPlaceholder = bodyCandidates.find(editor =>
+    (editor.textContent || '').includes('从这里开始写正文'),
+  )
+  if (byPlaceholder)
+    return byPlaceholder
+
+  if (titleInput) {
+    const band = titleInput.getBoundingClientRect()
+    const belowTitle = bodyCandidates.filter((editor) => {
+      const rect = editor.getBoundingClientRect()
+      return rect.top >= band.bottom - 8
+    })
+    if (belowTitle.length > 0) {
+      return belowTitle.sort((a, b) => getEditorArea(b) - getEditorArea(a))[0]
+    }
+  }
+
+  return bodyCandidates.sort((a, b) => getEditorArea(b) - getEditorArea(a))[0]
+}
+
 // 微信公众号内容填充函数（在页面主世界中执行）
 // 注意：需要先调用 injectUtils 注入 window.waitFor
 async function fillWechatContent(title, htmlBody) {
   /**
    * 后台改版后可能存在多个 `.ProseMirror`（标题区也可能是 ProseMirror），
    * `querySelector('.ProseMirror')` 常会命中标题编辑器，导致正文 HTML 被贴进标题。
+   * 另外，正文编辑器有时会比标题编辑器晚挂载，这时也要继续等待，不能把唯一节点误判成正文。
    */
   function pickWechatBodyProseMirror() {
     const nodes = [...document.querySelectorAll('.ProseMirror')]
     if (nodes.length === 0)
       return null
-    if (nodes.length === 1)
-      return nodes[0]
-
-    const byPlaceholder = nodes.find(el =>
-      (el.textContent || '').includes('从这里开始写正文'),
-    )
-    if (byPlaceholder)
-      return byPlaceholder
 
     const titleInput = document.querySelector('#title')
-    if (titleInput) {
-      const band = titleInput.getBoundingClientRect()
-      const belowTitle = nodes.filter((el) => {
-        const r = el.getBoundingClientRect()
-        return r.top >= band.bottom - 8
-      })
-      if (belowTitle.length > 0) {
-        return belowTitle.sort(
-          (a, b) => (b.clientHeight * b.clientWidth) - (a.clientHeight * a.clientWidth),
-        )[0]
-      }
-    }
-
-    return nodes.sort(
-      (a, b) => (b.clientHeight * b.clientWidth) - (a.clientHeight * a.clientWidth),
-    )[0]
+    const titleEditor = document.querySelector('.title-editor__input .ProseMirror')
+    return pickWechatBodyProseMirrorCandidate(nodes, { titleInput, titleEditor })
   }
 
   async function waitForBodyEditor(timeout = 15000) {
@@ -351,5 +366,9 @@ async function syncWechatContent(tab, content, helpers) {
 }
 
 // 导出
-export { WechatPlatform, fillWechatContent, syncWechatContent }
-
+export {
+  WechatPlatform,
+  fillWechatContent,
+  pickWechatBodyProseMirrorCandidate,
+  syncWechatContent,
+}

--- a/tests/wechat.test.mjs
+++ b/tests/wechat.test.mjs
@@ -1,0 +1,90 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { pickWechatBodyProseMirrorCandidate } from '../packages/core/src/platforms/wechat.js'
+
+function createEditor({
+  textContent = '',
+  top = 0,
+  height = 120,
+  width = 640,
+  classes = [],
+} = {}) {
+  const classSet = new Set(classes)
+  const rect = {
+    top,
+    bottom: top + height,
+    left: 0,
+    right: width,
+    width,
+    height,
+  }
+
+  return {
+    textContent,
+    clientHeight: height,
+    clientWidth: width,
+    getBoundingClientRect: () => rect,
+    closest: (selector) => {
+      const selectors = selector.split(',').map(item => item.trim().replace(/^\./, ''))
+      return selectors.some(item => classSet.has(item)) ? { selector } : null
+    },
+  }
+}
+
+function createTitleInput({ top = 0, height = 48 } = {}) {
+  return {
+    getBoundingClientRect: () => ({
+      top,
+      bottom: top + height,
+      left: 0,
+      right: 640,
+      width: 640,
+      height,
+    }),
+  }
+}
+
+test('只有标题编辑器时返回 null，避免把正文贴到标题', () => {
+  const titleInput = createTitleInput()
+  const titleEditor = createEditor({
+    top: 8,
+    height: 40,
+    width: 640,
+    classes: ['title-editor__input'],
+  })
+
+  const picked = pickWechatBodyProseMirrorCandidate([titleEditor], { titleInput, titleEditor })
+  assert.equal(picked, null)
+})
+
+test('标题和正文同时存在时优先选择正文编辑器', () => {
+  const titleInput = createTitleInput()
+  const titleEditor = createEditor({
+    top: 8,
+    height: 40,
+    width: 640,
+    classes: ['title-editor__input'],
+  })
+  const bodyEditor = createEditor({
+    textContent: '从这里开始写正文',
+    top: 180,
+    height: 520,
+    width: 720,
+  })
+
+  const picked = pickWechatBodyProseMirrorCandidate([titleEditor, bodyEditor], { titleInput, titleEditor })
+  assert.equal(picked, bodyEditor)
+})
+
+test('没有标题编辑器时保留单编辑器场景的兼容性', () => {
+  const bodyEditor = createEditor({
+    textContent: '正文内容',
+    top: 120,
+    height: 480,
+    width: 720,
+  })
+
+  const picked = pickWechatBodyProseMirrorCandidate([bodyEditor], {})
+  assert.equal(picked, bodyEditor)
+})


### PR DESCRIPTION
## Summary / 概述
- fix a WeChat race where the title ProseMirror mounts before the body editor
- keep waiting until a non-title ProseMirror appears before pasting HTML
- add a regression test for the title-only mount sequence

## Type of Change / 更改类型
- [x] Bug fix / 修复 Bug (non-breaking change that fixes an issue / 修复问题的非破坏性更改)
- [ ] New feature / 新功能 (non-breaking change that adds functionality / 添加功能的非破坏性更改)
- [ ] Breaking change / 破坏性更改 (fix or feature that would cause existing functionality to not work as expected / 会导致现有功能无法正常工作的修复或功能)
- [ ] Documentation update / 文档更新
- [ ] Performance improvement / 性能优化
- [ ] Code refactoring / 代码重构
- [ ] Other / 其他 (please describe / 请描述):

## Changes Made / 更改内容
- extract a reusable WeChat body-editor picker that excludes title editors
- return `null` when only the title editor is mounted so the sync flow keeps waiting for the body editor
- cover the race condition with a Node test

## Testing / 测试
### Testing Checklist / 测试清单
- [x] I have tested this code locally / 我已在本地测试此代码
- [x] All existing tests pass / 所有现有测试通过
- [x] I have added tests for new functionality / 我已为新功能添加测试
- [ ] I have tested on the affected platform(s) / 我已在受影响的平台上测试
- [ ] I have verified the changes work in the target browser(s) / 我已验证更改在目标浏览器中有效

### Manual Testing Steps / 手动测试步骤
1. Open the WeChat draft editor where the title ProseMirror mounts before the body editor.
2. Trigger article sync from the extension.
3. Confirm the title stays as plain title text and the article HTML is pasted into the body editor after it appears.

## Additional Notes / 补充说明
- `pnpm lint` still reports existing MV3 Firefox compatibility warnings/errors unrelated to this patch.