### PR TITLE
fix(wechat): inject official account content via JSAPI

### DIFF
--- a/packages/core/src/platforms/wechat.js
+++ b/packages/core/src/platforms/wechat.js
@@ -160,42 +160,57 @@ async function fillWechatContent(title, htmlBody) {
         editor.innerHTML = ''
       }
 
-      // 使用真实剪贴板 API 写入 HTML，然后模拟 Ctrl+V
-      try {
-        // 创建 ClipboardItem 并写入剪贴板
-        const blob = new Blob([htmlBody], { type: 'text/html' })
-        const plainBlob = new Blob([htmlBody.replace(/<[^>]*>/g, '')], { type: 'text/plain' })
-        const clipboardItem = new ClipboardItem({
-          'text/html': blob,
-          'text/plain': plainBlob,
+      const plainText = htmlBody.replace(/<[^>]*>/g, '')
+      const hasImageInSource = /<img\b/i.test(htmlBody)
+      let injected = false
+      let injectError = ''
+
+      // 优先使用微信编辑器 JSAPI。合成 Ctrl+V 事件不会触发真实粘贴；
+      // 直接写 innerHTML 也不会可靠同步到 ProseMirror 的文档模型。
+      if (window.__MP_Editor_JSAPI__ && typeof window.__MP_Editor_JSAPI__.invoke === 'function') {
+        injected = await new Promise((resolve) => {
+          let done = false
+          const finish = (ok, err) => {
+            if (done)
+              return
+            done = true
+            if (err)
+              injectError = err.message || String(err)
+            resolve(ok)
+          }
+
+          try {
+            window.__MP_Editor_JSAPI__.invoke({
+              apiName: 'mp_editor_set_content',
+              apiParam: { content: htmlBody },
+              sucCb: () => finish(true),
+              errCb: err => finish(false, err),
+            })
+          }
+          catch (err) {
+            finish(false, err)
+          }
+
+          setTimeout(() => finish(false, new Error('mp_editor_set_content 调用超时')), 5000)
         })
-        await navigator.clipboard.write([clipboardItem])
-        console.log('[COSE] HTML 已写入真实剪贴板')
 
-        // 模拟 Ctrl+V 粘贴
-        editor.dispatchEvent(new KeyboardEvent('keydown', {
-          key: 'v',
-          code: 'KeyV',
-          ctrlKey: true,
-          bubbles: true,
-        }))
-        editor.dispatchEvent(new KeyboardEvent('keyup', {
-          key: 'v',
-          code: 'KeyV',
-          ctrlKey: true,
-          bubbles: true,
-        }))
-        console.log('[COSE] 已模拟 Ctrl+V 粘贴')
-
-        // 等待内容渲染
-        await new Promise(r => setTimeout(r, 800))
+        if (injected) {
+          console.log('[COSE] 微信内容已通过 mp_editor_set_content 注入')
+          await new Promise(r => setTimeout(r, 800))
+        }
+        else {
+          console.warn('[COSE] mp_editor_set_content 注入失败:', injectError)
+        }
       }
-      catch (clipboardErr) {
-        console.log('[COSE] 真实剪贴板失败，降级到 DataTransfer:', clipboardErr.message)
-        // 降级到 DataTransfer 方案
+
+      if (!injected) {
+        if (hasImageInSource) {
+          console.warn('[COSE] 正文包含图片，但微信 JSAPI 不可用；paste 兜底可能无法保留图片')
+        }
+
         const dt = new DataTransfer()
         dt.setData('text/html', htmlBody)
-        dt.setData('text/plain', htmlBody.replace(/<[^>]*>/g, ''))
+        dt.setData('text/plain', plainText)
 
         const pasteEvent = new ClipboardEvent('paste', {
           bubbles: true,
@@ -204,24 +219,22 @@ async function fillWechatContent(title, htmlBody) {
         })
 
         editor.dispatchEvent(pasteEvent)
-        console.log('[COSE] 微信内容已通过 paste 事件注入（降级方案）')
+        console.log('[COSE] 微信内容已通过 paste 事件注入（兜底方案）')
 
         // 等待内容渲染
-        await new Promise(r => setTimeout(r, 500))
+        await new Promise(r => setTimeout(r, 800))
       }
 
       // 验证内容是否注入成功
-      const wordCount = editor.textContent?.length || 0
-      if (wordCount === 0) {
-        // 备用方案：直接设置 innerHTML
-        console.log('[COSE] 粘贴未生效，尝试直接设置 innerHTML')
-        editor.innerHTML = htmlBody
-        editor.dispatchEvent(new Event('input', { bubbles: true }))
-      }
+      const wordCount = editor.textContent?.trim().length || 0
+      const imageCount = editor.querySelectorAll?.('img').length || 0
+      const hasEditorContent = wordCount > 0 || imageCount > 0 || injected
 
       return {
-        success: true,
-        wordCount: editor.textContent?.length || 0,
+        success: hasEditorContent,
+        error: hasEditorContent ? undefined : (injectError || '正文注入后未检测到有效内容'),
+        wordCount,
+        imageCount,
         titleFilled: titleInput?.value === title || titleEditor?.textContent?.trim() === title,
       }
     }

--- a/tests/wechat.test.mjs
+++ b/tests/wechat.test.mjs
@@ -1,7 +1,10 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
 
-import { pickWechatBodyProseMirrorCandidate } from '../packages/core/src/platforms/wechat.js'
+import {
+  fillWechatContent,
+  pickWechatBodyProseMirrorCandidate,
+} from '../packages/core/src/platforms/wechat.js'
 
 function createEditor({
   textContent = '',
@@ -42,6 +45,159 @@ function createTitleInput({ top = 0, height = 48 } = {}) {
       width: 640,
       height,
     }),
+  }
+}
+
+function createInputElement() {
+  return {
+    value: '',
+    focus() {},
+    dispatchEvent() {},
+  }
+}
+
+function createProseMirrorElement({
+  textContent = '',
+  classes = [],
+  onDispatchEvent,
+} = {}) {
+  const classSet = new Set(classes)
+  let html = ''
+  let text = textContent
+  let imageCount = 0
+
+  return {
+    clientHeight: 480,
+    clientWidth: 720,
+    focus() {},
+    dispatchEvent(event) {
+      onDispatchEvent?.(event)
+      return true
+    },
+    get textContent() {
+      return text
+    },
+    set textContent(value) {
+      text = value
+    },
+    get innerHTML() {
+      return html
+    },
+    set innerHTML(value) {
+      html = value
+      if (value === '') {
+        text = ''
+        imageCount = 0
+      }
+    },
+    setRenderedContent(value) {
+      html = value
+      text = value.replace(/<[^>]*>/g, '')
+      imageCount = (value.match(/<img\b/gi) || []).length
+    },
+    querySelectorAll(selector) {
+      if (selector === 'img')
+        return Array.from({ length: imageCount }, () => ({}))
+      return []
+    },
+    getBoundingClientRect: () => ({
+      top: classSet.has('title-editor__input') ? 8 : 180,
+      bottom: classSet.has('title-editor__input') ? 48 : 660,
+      left: 0,
+      right: 720,
+      width: 720,
+      height: classSet.has('title-editor__input') ? 40 : 480,
+    }),
+    closest: (selector) => {
+      const selectors = selector.split(',').map(item => item.trim().replace(/^\./, ''))
+      return selectors.some(item => classSet.has(item)) ? { selector } : null
+    },
+  }
+}
+
+async function withWechatFillEnvironment({ jsapiInvoke, bodyEditor, callback }) {
+  const previousGlobals = {
+    window: globalThis.window,
+    document: globalThis.document,
+    Event: globalThis.Event,
+    ClipboardEvent: globalThis.ClipboardEvent,
+    DataTransfer: globalThis.DataTransfer,
+    setTimeout: globalThis.setTimeout,
+  }
+
+  const titleInput = createInputElement()
+  const titleEditor = createProseMirrorElement({ classes: ['title-editor__input'] })
+
+  class TestEvent {
+    constructor(type, init = {}) {
+      this.type = type
+      Object.assign(this, init)
+    }
+  }
+
+  class TestDataTransfer {
+    constructor() {
+      this.data = new Map()
+    }
+
+    setData(type, value) {
+      this.data.set(type, value)
+    }
+
+    getData(type) {
+      return this.data.get(type)
+    }
+  }
+
+  globalThis.Event = TestEvent
+  globalThis.ClipboardEvent = TestEvent
+  globalThis.DataTransfer = TestDataTransfer
+  globalThis.setTimeout = (fn) => {
+    fn()
+    return 0
+  }
+
+  globalThis.window = {
+    waitFor: async (selector) => {
+      if (selector === '#title')
+        return titleInput
+      if (selector === '.title-editor__input .ProseMirror')
+        return titleEditor
+      return null
+    },
+    HTMLTextAreaElement: class HTMLTextAreaElement {},
+    HTMLInputElement: class HTMLInputElement {},
+  }
+
+  if (jsapiInvoke) {
+    globalThis.window.__MP_Editor_JSAPI__ = {
+      invoke: jsapiInvoke,
+    }
+  }
+
+  globalThis.document = {
+    querySelectorAll: selector => selector === '.ProseMirror'
+      ? [titleEditor, bodyEditor]
+      : [],
+    querySelector: (selector) => {
+      if (selector === '#title')
+        return titleInput
+      if (selector === '.title-editor__input .ProseMirror')
+        return titleEditor
+      return null
+    },
+  }
+
+  try {
+    return await callback({ titleInput, titleEditor })
+  }
+  finally {
+    for (const [key, value] of Object.entries(previousGlobals)) {
+      if (value === undefined)
+        delete globalThis[key]
+      else
+        globalThis[key] = value
+    }
   }
 }
 
@@ -87,4 +243,54 @@ test('没有标题编辑器时保留单编辑器场景的兼容性', () => {
 
   const picked = pickWechatBodyProseMirrorCandidate([bodyEditor], {})
   assert.equal(picked, bodyEditor)
+})
+
+test('正文填充优先使用微信编辑器 JSAPI 注入含图 HTML', async () => {
+  const htmlBody = '<p>正文</p><img src="https://example.com/a.png">'
+  const bodyEditor = createProseMirrorElement({
+    textContent: '从这里开始写正文',
+  })
+  const calls = []
+
+  const result = await withWechatFillEnvironment({
+    bodyEditor,
+    jsapiInvoke: (params) => {
+      calls.push(params)
+      bodyEditor.setRenderedContent(params.apiParam.content)
+      params.sucCb({})
+    },
+    callback: () => fillWechatContent('测试标题', htmlBody),
+  })
+
+  assert.equal(calls.length, 1)
+  assert.equal(calls[0].apiName, 'mp_editor_set_content')
+  assert.deepEqual(calls[0].apiParam, { content: htmlBody })
+  assert.equal(result.success, true)
+  assert.equal(result.wordCount, 2)
+  assert.equal(result.imageCount, 1)
+})
+
+test('微信 JSAPI 不可用时使用 paste 事件兜底而不是直接写 innerHTML', async () => {
+  const htmlBody = '<p>正文</p>'
+  let pasteEvent
+  const bodyEditor = createProseMirrorElement({
+    textContent: '从这里开始写正文',
+    onDispatchEvent: (event) => {
+      if (event.type === 'paste') {
+        pasteEvent = event
+        bodyEditor.setRenderedContent(event.clipboardData.getData('text/html'))
+      }
+    },
+  })
+
+  const result = await withWechatFillEnvironment({
+    bodyEditor,
+    callback: () => fillWechatContent('测试标题', htmlBody),
+  })
+
+  assert.equal(pasteEvent?.type, 'paste')
+  assert.equal(pasteEvent.clipboardData.getData('text/html'), htmlBody)
+  assert.equal(bodyEditor.innerHTML, htmlBody)
+  assert.equal(result.success, true)
+  assert.equal(result.wordCount, 2)
 })

--- a/tests/wechat.test.mjs
+++ b/tests/wechat.test.mjs
@@ -65,10 +65,12 @@ function createProseMirrorElement({
   let html = ''
   let text = textContent
   let imageCount = 0
+  const innerHTMLWrites = []
 
   return {
     clientHeight: 480,
     clientWidth: 720,
+    innerHTMLWrites,
     focus() {},
     dispatchEvent(event) {
       onDispatchEvent?.(event)
@@ -84,6 +86,7 @@ function createProseMirrorElement({
       return html
     },
     set innerHTML(value) {
+      innerHTMLWrites.push(value)
       html = value
       if (value === '') {
         text = ''
@@ -291,6 +294,7 @@ test('微信 JSAPI 不可用时使用 paste 事件兜底而不是直接写 inner
   assert.equal(pasteEvent?.type, 'paste')
   assert.equal(pasteEvent.clipboardData.getData('text/html'), htmlBody)
   assert.equal(bodyEditor.innerHTML, htmlBody)
+  assert.deepEqual(bodyEditor.innerHTMLWrites, [''])
   assert.equal(result.success, true)
   assert.equal(result.wordCount, 2)
 })


### PR DESCRIPTION
## Summary / 概述
Use the WeChat official account editor JSAPI as the primary body injection path for synced articles. This avoids relying on synthetic Ctrl+V keyboard events and direct ProseMirror `innerHTML` mutation, which can produce title-only drafts when the article contains images.

## Related Issue / 关联 Issue
Closes #249

## Type of Change / 更改类型
- [x] Bug fix / 修复 Bug (non-breaking change that fixes an issue / 修复问题的非破坏性更改)
- [ ] New feature / 新功能 (non-breaking change that adds functionality / 添加功能的非破坏性更改)
- [ ] Breaking change / 破坏性更改 (fix or feature that would cause existing functionality to not work as expected / 会导致现有功能无法正常工作的修复或功能)
- [ ] Documentation update / 文档更新
- [ ] Performance improvement / 性能优化
- [ ] Code refactoring / 代码重构
- [ ] Other / 其他 (please describe / 请描述):

## Changes Made / 更改内容
- Prefer `window.__MP_Editor_JSAPI__.invoke({ apiName: 'mp_editor_set_content' })` when filling WeChat official account body content.
- Keep a `ClipboardEvent` + `DataTransfer` fallback for non-JSAPI cases.
- Remove the synthetic Ctrl+V path and the direct `innerHTML` body fallback.
- Return a real success status based on detected editor content and JSAPI completion.
- Add regression tests for JSAPI injection and paste fallback behavior.

## Implementation Details / 实现细节

**Key Changes / 主要更改:**
- `fillWechatContent` now calls `mp_editor_set_content` in the page main world when the WeChat editor JSAPI is available.
- The fallback path dispatches a paste event with `text/html` and `text/plain` data instead of writing directly to the ProseMirror DOM.
- The result now includes `wordCount` and `imageCount`, and can report a failed body injection instead of always returning success.

**Technical Notes / 技术说明:**
- Synthetic keyboard events are untrusted and do not trigger the browser's native paste action.
- Directly assigning `innerHTML` on a ProseMirror node does not reliably update ProseMirror's document state.
- The JSAPI path matches the approach used by the doocs/md WeChat extension for setting official account editor content.

## Testing / 测试

### Testing Checklist / 测试清单
- [x] I have tested this code locally / 我已在本地测试此代码
- [x] All existing tests pass / 所有现有测试通过
- [x] I have added tests for new functionality / 我已为新功能添加测试
- [x] I have tested on the affected platform(s) / 我已在受影响的平台上测试
- [x] I have verified the changes work in the target browser(s) / 我已验证更改在目标浏览器中有效

### Manual Testing Steps / 手动测试步骤
1. Run `pnpm test`.
2. Run `pnpm build`.
3. Load the built extension in Chrome.
4. Sync a WeChat article containing text and images.
5. Confirm the article body and images appear in the WeChat official account editor and remain after saving as a draft.

## Screenshots/Videos / 截图/视频
Not included.

## Reviewer Checklist / 审阅者清单
- [ ] Code follows the project's style guidelines / 代码遵循项目的风格指南
- [ ] Changes are well-documented / 更改有良好的文档说明
- [ ] No breaking changes or clearly documented if present / 无破坏性更改，或已清楚记录
- [ ] Security implications have been considered / 已考虑安全影响
- [ ] Performance impact has been evaluated / 已评估性能影响
- [ ] All discussions have been resolved / 所有讨论已解决

## Additional Notes / 补充说明
Local verification:
- `pnpm test` passed.
- `pnpm build` passed.
- Manual Chrome + WeChat official account editor verification passed with image-containing content.
- `pnpm lint` currently fails on existing `web-ext lint` checks for the generated Chromium manifest, including `MANIFEST_FIELD_UNSUPPORTED` for `/background/service_worker` and `EXTENSION_ID_REQUIRED`, plus existing warnings in generated bundles.