### PR TITLE
ci: add GitHub Actions workflow for PR validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,54 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+# Fork PRs receive a read-only GITHUB_TOKEN; no repository secrets required.
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build extension (Chromium)
+        run: pnpm build
+
+      - name: Verify Chromium build artifacts
+        run: |
+          test -f apps/extension/dist/manifest.json
+          test -f apps/extension/dist/popup.html
+          test -f apps/extension/dist/offscreen.html
+          test -f apps/extension/dist/bundles/background.js
+
+      - name: Run tests
+        run: pnpm test
+
+      - name: Build extension (Firefox) and lint
+        run: |
+          pnpm build:firefox
+          pnpm -C apps/extension lint


### PR DESCRIPTION
## Summary

- Add a `CI` GitHub Actions workflow for `pull_request` and `push` to `main`
- Run `pnpm install --frozen-lockfile`, Chromium build, artifact checks, unit tests, Firefox build, and `web-ext lint`
- Use read-only `permissions` and no repository secrets so fork PRs can run the same checks

## Fork PR notes

- Uses the standard `pull_request` event (not `pull_request_target`)
- No secrets or write permissions required
- First-time contributors from forks may still need maintainer approval before GitHub runs workflows (repository setting)

## Test plan

- [x] Local: `pnpm install --frozen-lockfile`
- [x] Local: `pnpm build` + artifact checks
- [x] Local: `pnpm test`
- [x] Local: `pnpm build:firefox` + `pnpm -C apps/extension lint`
- [ ] CI passes on this PR after merge workflow is available on `main`
